### PR TITLE
fix: remove MIPS build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,11 +113,7 @@ release-linux: $(DIST) \
 	$(DIST)/$(EXECUTABLE)_linux-arm-5 \
 	$(DIST)/$(EXECUTABLE)_linux-arm-6 \
 	$(DIST)/$(EXECUTABLE)_linux-arm-7 \
-	$(DIST)/$(EXECUTABLE)_linux-arm64 \
-	$(DIST)/$(EXECUTABLE)_linux-mips \
-	$(DIST)/$(EXECUTABLE)_linux-mips64 \
-	$(DIST)/$(EXECUTABLE)_linux-mipsle \
-	$(DIST)/$(EXECUTABLE)_linux-mips64le
+	$(DIST)/$(EXECUTABLE)_linux-arm64
 
 $(DIST)/$(EXECUTABLE)_linux-386:
 	GOOS=linux GOARCH=386 $(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)
@@ -137,17 +133,6 @@ $(DIST)/$(EXECUTABLE)_linux-arm-7:
 $(DIST)/$(EXECUTABLE)_linux-arm64:
 	GOOS=linux GOARCH=arm64 $(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)
 
-$(DIST)/$(EXECUTABLE)_linux-mips:
-	GOOS=linux GOARCH=mips $(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)
-
-$(DIST)/$(EXECUTABLE)_linux-mips64:
-	GOOS=linux GOARCH=mips64 $(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)
-
-$(DIST)/$(EXECUTABLE)_linux-mipsle:
-	GOOS=linux GOARCH=mipsle $(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)
-
-$(DIST)/$(EXECUTABLE)_linux-mips64le:
-	GOOS=linux GOARCH=mips64le $(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)
 
 .PHONY: release-darwin
 release-darwin: $(DIST) \


### PR DESCRIPTION
## Summary

- Remove linux/mips, linux/mips64, linux/mipsle, and linux/mips64le from release build targets
- `modernc.org/sqlite` does not support MIPS architectures (its `libc/time` package has no Go files matching those build constraints)
- All other targets (386, amd64, arm5/6/7, arm64) are unaffected

## Test plan

- [ ] Verify `make release` completes without errors
- [x] Confirm existing platform binaries are still produced