### PR TITLE
chore: remove linux/mips, linux/mips64, linux/mipsle, and linux/mips64le from release build targets

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-27T16:44:39.555722+02:00",
-  "version": "v1.3.1-dirty",
+  "generated_at": "2026-05-29T13:55:43.003489957Z",
+  "version": "1.3.4",
   "files": [
     {
       "path": ".editorconfig"

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = true

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Setup qemu
         id: qemu
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Setup buildx
         id: buildx

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,3 @@ coverage*
 /results
 /bin
 /out
-*.db

--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,6 @@ lint:
 generate:
 	go generate $(GENERATE)
 
-.PHONY: sqlc
-sqlc:
-	sqlc generate
-	cp db/schema.sql gopodder/sqlcgen/schema.sql
-
 .PHONY: test
 test:
 	go test -coverprofile coverage.out $(PACKAGES)


### PR DESCRIPTION
Remove linux/mips, linux/mips64, linux/mipsle, and linux/mips64le from release build targets.