### PR TITLE
fix: use git describe --tags --dirty for version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ifndef VERSION
 	ifeq ($(GITHUB_REF_TYPE), tag)
 		VERSION ?= $(subst v,,$(GITHUB_REF_NAME))
 	else
-		VERSION ?= $(shell git describe --tags --abbrev=0)-dirty
+		VERSION ?= $(shell git describe --tags --dirty 2>/dev/null || echo dev)
 	endif
 endif
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `-dirty` suffix with `git describe --tags --dirty`
- Version now shows commit distance and short hash when ahead of a tag
- Only appends `-dirty` when there are actual uncommitted changes
- Falls back to `dev` when no tags exist

Examples:
- On tag: `v1.0.0`
- 2 commits ahead, clean: `v1.0.0-2-g8d82caf`
- 2 commits ahead, uncommitted changes: `v1.0.0-2-g8d82caf-dirty`
- No tags: `dev`

## Test plan

- [x] `make build && ./bin/gopodder --version` shows correct version
- [x] Status page displays version correctly
- [x] Login page footer shows version correctly