### PR TITLE
feat: log version info on server startup

### DIFF
--- a/gopodder/server.go
+++ b/gopodder/server.go
@@ -53,6 +53,8 @@ func Run(logger *slog.Logger, cfg Config) error {
 		go startDebugServer(logger, cfg.DebugAddr)
 	}
 
+	logger.Info("goPodder", "version", cfg.Build.Version, "revision", cfg.Build.Revision, "go", cfg.Build.GoVersion, "platform", cfg.Build.Platform)
+
 	errCh := make(chan error, 1)
 	go func() {
 		logger.Info("starting server", "addr", listenAddr)


### PR DESCRIPTION
## Summary

- Log version, revision, Go version, and platform as the first line on startup
- Makes it easy to identify the build when reading logs or when users share them in issue reports

Example output:
```
level=INFO msg=goPodder version=1.0.0 revision=abc123 go=go1.26.3 platform=linux/amd64
level=INFO msg="starting server" addr=0.0.0.0:8080
```

## Test plan

- [x] Start the server and verify version info appears before "starting server" line