### PR TITLE
fix: ensure devices reappear after deletion on next sync

### DIFF
--- a/gopodder/api_subscriptions.go
+++ b/gopodder/api_subscriptions.go
@@ -61,6 +61,8 @@ func (a *API) handleGetSubscriptions(w http.ResponseWriter, r *http.Request) {
 	}
 	username := UsernameFromContext(r.Context())
 
+	_ = a.store.UpsertDevice(r.Context(), username, deviceID, DeviceUpdate{})
+
 	subs, err := a.store.GetSubscriptions(r.Context(), username)
 	if err != nil {
 		a.logger.Error("failed to get subscriptions", "err", err)
@@ -118,6 +120,8 @@ func (a *API) handleGetSubscriptionChanges(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	username := UsernameFromContext(r.Context())
+
+	_ = a.store.UpsertDevice(r.Context(), username, deviceID, DeviceUpdate{})
 
 	since := parseQueryInt64(r, "since", 0)
 

--- a/gopodder/web/pages.templ
+++ b/gopodder/web/pages.templ
@@ -345,7 +345,7 @@ templ UserDetailPage(data UserDetailData) {
 		@alertSuccess(data.Flash)
 		<div class="section">
 			<h2>Devices</h2>
-			<p class="setting-desc">Devices are registered automatically by your podcast apps. All devices share the same subscriptions and stay in sync.</p>
+			<p class="setting-desc">Devices register automatically when your podcast app syncs and share the same subscriptions. Removing one here cleans up the list, but it will reappear on the next sync unless you change the user's password.</p>
 			if len(data.Devices) == 0 {
 				<p>No devices registered yet.</p>
 			} else {

--- a/gopodder/web/pages_templ.go
+++ b/gopodder/web/pages_templ.go
@@ -1081,7 +1081,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, " <div class=\"section\"><h2>Devices</h2><p class=\"setting-desc\">Devices are registered automatically by your podcast apps. All devices share the same subscriptions and stay in sync.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, " <div class=\"section\"><h2>Devices</h2><p class=\"setting-desc\">Devices register automatically when your podcast app syncs and share the same subscriptions. Removing one here cleans up the list, but it will reappear on the next sync unless you change the user's password.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
- Add UpsertDevice to GET subscription handlers so deleted devices re-register on next sync
- Update device section description to explain the behavior and how to permanently disconnect a device