### PR TITLE
fix: session handling, input validation, and OPML import

### DIFF
--- a/gopodder/auth.go
+++ b/gopodder/auth.go
@@ -85,6 +85,10 @@ func (a *API) handleLogin(w http.ResponseWriter, r *http.Request) {
 	sessionID := uuid.New().String()
 	_ = a.store.UpdateUserSession(r.Context(), username, &sessionID, time.Now())
 
+	maxAge, _ := a.store.GetSetting(r.Context(), SettingSessionMaxAge)
+	maxAgeHours, _ := strconv.ParseInt(maxAge, 10, 64)
+	maxAgeHours = cmp.Or(maxAgeHours, defaultSessionMaxAgeHours)
+
 	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 	http.SetCookie(w, &http.Cookie{
 		Name:     "sessionid",
@@ -93,6 +97,7 @@ func (a *API) handleLogin(w http.ResponseWriter, r *http.Request) {
 		HttpOnly: true,
 		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
+		MaxAge:   int(maxAgeHours) * 3600,
 	})
 
 	a.logger.Debug("user logged in", "username", username)

--- a/gopodder/web_handler.go
+++ b/gopodder/web_handler.go
@@ -814,6 +814,10 @@ func (h *WebHandler) handleCreateAccount(w http.ResponseWriter, r *http.Request)
 	if role != RoleAdmin {
 		role = RoleStandard
 	}
+	if _, err := h.store.GetAccount(r.Context(), username); err == nil {
+		http.Redirect(w, r, "/admin/accounts?error=Username+already+exists.", http.StatusSeeOther)
+		return
+	}
 	id := uuid.New().String()
 	if err := h.store.CreateAccount(r.Context(), id, username, hashPassword(password), role, time.Now()); err != nil {
 		h.logger.Error("failed to create account", "err", err, "username", username)

--- a/gopodder/web_handler.go
+++ b/gopodder/web_handler.go
@@ -330,6 +330,12 @@ func (h *WebHandler) handleSelfDeleteAccount(w http.ResponseWriter, r *http.Requ
 
 	h.deleteAccountCascade(r.Context(), acct.ID)
 	h.logger.Info("account self-deleted", "username", acct.Username)
+	http.SetCookie(w, &http.Cookie{
+		Name:   "web_session",
+		Value:  "",
+		Path:   "/",
+		MaxAge: -1,
+	})
 	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }
 

--- a/gopodder/web_handler.go
+++ b/gopodder/web_handler.go
@@ -643,6 +643,7 @@ func (h *WebHandler) importOPML(ctx context.Context, username string, r *http.Re
 	if err != nil {
 		return 0, err
 	}
+	urls = filterValidURLs(urls)
 	now := time.Now().Unix()
 	for _, u := range urls {
 		_ = h.store.ReactivateSubscription(ctx, username, u, now)

--- a/gopodder/web_handler.go
+++ b/gopodder/web_handler.go
@@ -834,6 +834,10 @@ func (h *WebHandler) handleUpdateAccount(w http.ResponseWriter, r *http.Request)
 	role := r.FormValue("role")
 
 	if username != "" {
+		if !isValidUsername(username) {
+			http.Redirect(w, r, "/admin/accounts/"+id+"?error=Invalid+username.", http.StatusSeeOther)
+			return
+		}
 		_ = h.store.UpdateAccountUsername(r.Context(), id, username)
 	}
 	if role == RoleAdmin || role == RoleStandard {


### PR DESCRIPTION
- gPodder API session cookie now persists across app restarts (missing MaxAge)
- Session cookie cleared when a user deletes their own account
- OPML import rejects non-http/https URLs (was the only unfiltered path)
- Admin account creation shows proper error on duplicate username
- Admin account update validates username format