### PR TITLE
fix: disable subscription sharing by default

### DIFF
--- a/gopodder/web_handler.go
+++ b/gopodder/web_handler.go
@@ -1158,7 +1158,7 @@ func parseFormInt(s string) int {
 func (h *WebHandler) isSettingEnabled(ctx context.Context, key string) bool {
 	val, err := h.store.GetSetting(ctx, key)
 	if err != nil {
-		return key == SettingAllowUserCreation || key == SettingAllowSharing
+		return key == SettingAllowUserCreation
 	}
 	return val == "true"
 }

--- a/gopodder/web_handler_test.go
+++ b/gopodder/web_handler_test.go
@@ -1635,6 +1635,7 @@ func TestSessionExpiry(t *testing.T) {
 
 func TestHandlePublicOPML(t *testing.T) {
 	store := newMockStore()
+	store.settings[SettingAllowSharing] = "true"
 	token := "test-share-token"
 	store.users["gpuser1"] = &User{Username: "gpuser1", PWHash: hashPassword("pass"), AccountID: "acct1", ShareToken: &token}
 	store.subscriptions["gpuser1"] = []string{"http://a.com/feed", "http://b.com/feed"}
@@ -1693,6 +1694,7 @@ func TestHandlePublicOPML(t *testing.T) {
 
 func TestHandlePublicRSS(t *testing.T) {
 	store := newMockStore()
+	store.settings[SettingAllowSharing] = "true"
 	token := "test-share-token"
 	store.users["gpuser1"] = &User{Username: "gpuser1", PWHash: hashPassword("pass"), AccountID: "acct1", ShareToken: &token}
 	store.subscriptions["gpuser1"] = []string{"http://a.com/feed", "http://b.com/feed"}


### PR DESCRIPTION
Sharing now requires an admin to enable it in Settings. Previously it was enabled by default on fresh instances.