### PR TITLE
feat: add environment variable support for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,17 @@ Open `http://localhost:8080` in your browser. On first launch you'll be asked to
 
 ### Configuration flags
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--listen-address` | `0.0.0.0:8080` | HTTP listen address (host:port) |
-| `--debug-address` | | Debug/metrics listen address (disabled if empty) |
-| `--db-backend` | `sqlite` | Database backend (`sqlite` or `postgres`) |
-| `--db-path` | `gopodder.db` | Path to SQLite database file |
-| `--db-postgres` | | PostgreSQL connection string |
-| `--log-level` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
+All flags can also be set via environment variables. The env var takes precedence over the default but the flag takes precedence over the env var
+
+| Flag | Env var | Default | Description |
+|------|---------|---------|-------------|
+| `--listen-address` | `GOPODDER_LISTEN_ADDRESS` | `0.0.0.0:8080` | HTTP listen address (host:port) |
+| `--debug-address` | `GOPODDER_DEBUG_ADDRESS` | | Debug/metrics listen address (disabled if empty) |
+| `--db-backend` | `GOPODDER_DB_BACKEND` | `sqlite` | Database backend (`sqlite` or `postgres`) |
+| `--db-path` | `GOPODDER_DB_PATH` | `gopodder.db` | Path to SQLite database file |
+| `--db-postgres` | `GOPODDER_DB_POSTGRES` | | PostgreSQL connection string |
+| `--db-postgres-password` | `GOPODDER_DB_POSTGRES_PASSWORD` | | PostgreSQL password (injected into connection string) |
+| `--log-level` | `GOPODDER_LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
 
 ### Database backends
 
@@ -107,6 +110,21 @@ services:
 volumes:
   pg-data:
 ```
+
+### Podman Quadlet with secrets
+
+If you run Podman and want to avoid putting the database password in plain text, use `GOPODDER_DB_POSTGRES_PASSWORD` with a [Podman secret](https://docs.podman.io/en/latest/markdown/podman-secret-create.1.html):
+
+```ini
+[Container]
+Image=ghcr.io/cbrgm/gopodder:latest
+ContainerName=gopodder
+Environment=GOPODDER_DB_BACKEND=postgres
+Environment=GOPODDER_DB_POSTGRES=postgres://gopodder@pg_server:5432/gopodder
+Secret=gopodder_db_pass,type=env,target=GOPODDER_DB_POSTGRES_PASSWORD
+```
+
+The password is injected into the connection string at startup. Special characters in the password are URL-encoded automatically
 
 ## Connecting your podcast app
 

--- a/README.md
+++ b/README.md
@@ -140,9 +140,6 @@ Tested with:
 - [AntennaPod](https://antennapod.org/) (Android)
 - [gPodder](https://gpodder.github.io/) (Desktop, Linux/macOS/Windows)
 - [Cardo](https://github.com/cardo-podcast/cardo) (Windows/macOS/Linux)
-
-Should also work (not yet tested):
-
 - [KDE Kasts](https://apps.kde.org/kasts/) (Linux/Android/Windows)
 
 Any client that supports the gPodder.net sync protocol should work. If you've tested goPodder with a client not listed here, please [open an issue](https://github.com/cbrgm/gopodder/issues) and let us know

--- a/cmd/gopodder/main.go
+++ b/cmd/gopodder/main.go
@@ -18,18 +18,19 @@ var (
 )
 
 type CLI struct {
-	LogLevel string           `name:"log-level" default:"info" enum:"debug,info,warn,error" help:"Log level (debug, info, warn, error)."`
+	LogLevel string           `name:"log-level" default:"info" enum:"debug,info,warn,error" env:"GOPODDER_LOG_LEVEL" help:"Log level (debug, info, warn, error)."`
 	Version  kong.VersionFlag `name:"version" help:"Print version and exit."`
 
 	Serve ServeCmd `cmd:"" default:"withargs" help:"Start the gPodder sync server."`
 }
 
 type ServeCmd struct {
-	ListenAddr string `name:"listen-address" default:"0.0.0.0:8080" help:"HTTP listen address (host:port)."`
-	DebugAddr  string `name:"debug-address" default:"" help:"Debug/metrics listen address (e.g. 127.0.0.1:6060). Disabled if empty."`
-	DBBackend  string `name:"db-backend" default:"sqlite" enum:"sqlite,postgres" help:"Database backend (sqlite, postgres)."`
-	DBPath     string `name:"db-path" default:"gopodder.db" help:"Path to SQLite database file."`
-	DBPostgres string `name:"db-postgres" default:"" help:"PostgreSQL connection string (e.g. postgres://user:pass@host:5432/dbname)."`
+	ListenAddr         string `name:"listen-address" default:"0.0.0.0:8080" env:"GOPODDER_LISTEN_ADDRESS" help:"HTTP listen address (host:port)."`
+	DebugAddr          string `name:"debug-address" default:"" env:"GOPODDER_DEBUG_ADDRESS" help:"Debug/metrics listen address (e.g. 127.0.0.1:6060). Disabled if empty."`
+	DBBackend          string `name:"db-backend" default:"sqlite" enum:"sqlite,postgres" env:"GOPODDER_DB_BACKEND" help:"Database backend (sqlite, postgres)."`
+	DBPath             string `name:"db-path" default:"gopodder.db" env:"GOPODDER_DB_PATH" help:"Path to SQLite database file."`
+	DBPostgres         string `name:"db-postgres" default:"" env:"GOPODDER_DB_POSTGRES" help:"PostgreSQL connection string (e.g. postgres://user:pass@host:5432/dbname)."`
+	DBPostgresPassword string `name:"db-postgres-password" default:"" env:"GOPODDER_DB_POSTGRES_PASSWORD" help:"PostgreSQL password (injected into connection string if set)."`
 }
 
 func main() {
@@ -45,11 +46,12 @@ func main() {
 	switch ctx.Command() {
 	case "serve", "":
 		if err := gopodder.Run(logger, gopodder.Config{
-			ListenAddr: cli.Serve.ListenAddr,
-			DebugAddr:  cli.Serve.DebugAddr,
-			DBBackend:  cli.Serve.DBBackend,
-			DBPath:     cli.Serve.DBPath,
-			DBPostgres: cli.Serve.DBPostgres,
+			ListenAddr:         cli.Serve.ListenAddr,
+			DebugAddr:          cli.Serve.DebugAddr,
+			DBBackend:          cli.Serve.DBBackend,
+			DBPath:             cli.Serve.DBPath,
+			DBPostgres:         cli.Serve.DBPostgres,
+			DBPostgresPassword: cli.Serve.DBPostgresPassword,
 			Build: gopodder.BuildInfo{
 				Version:   Version,
 				Revision:  Revision,

--- a/gopodder/server.go
+++ b/gopodder/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -15,12 +16,13 @@ import (
 )
 
 type Config struct {
-	ListenAddr string
-	DebugAddr  string
-	DBBackend  string
-	DBPath     string
-	DBPostgres string
-	Build      BuildInfo
+	ListenAddr         string
+	DebugAddr          string
+	DBBackend          string
+	DBPath             string
+	DBPostgres         string
+	DBPostgresPassword string
+	Build              BuildInfo
 }
 
 func Run(logger *slog.Logger, cfg Config) error {
@@ -171,8 +173,28 @@ func openStore(cfg Config) (Store, error) {
 	case "sqlite", "":
 		return NewSQLiteStore(cfg.DBPath)
 	case "postgres":
-		return NewPostgresStore(cfg.DBPostgres)
+		dsn, err := buildPostgresDSN(cfg.DBPostgres, cfg.DBPostgresPassword)
+		if err != nil {
+			return nil, err
+		}
+		return NewPostgresStore(dsn)
 	default:
 		return nil, fmt.Errorf("unsupported database backend: %q (supported: sqlite, postgres)", cfg.DBBackend)
 	}
+}
+
+func buildPostgresDSN(dsn, password string) (string, error) {
+	if password == "" {
+		return dsn, nil
+	}
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return "", fmt.Errorf("parsing postgres connection string: %w", err)
+	}
+	if u.User != nil {
+		u.User = url.UserPassword(u.User.Username(), password)
+	} else {
+		u.User = url.UserPassword("", password)
+	}
+	return u.String(), nil
 }

--- a/gopodder/server_test.go
+++ b/gopodder/server_test.go
@@ -10,6 +10,58 @@ import (
 	"time"
 )
 
+func TestBuildPostgresDSN(t *testing.T) {
+	tests := []struct {
+		name     string
+		dsn      string
+		password string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "empty password returns dsn unchanged",
+			dsn:      "postgres://user@host:5432/db",
+			password: "",
+			want:     "postgres://user@host:5432/db",
+		},
+		{
+			name:     "password injected with existing user",
+			dsn:      "postgres://gopodder@host:5432/db",
+			password: "secret",
+			want:     "postgres://gopodder:secret@host:5432/db",
+		},
+		{
+			name:     "password replaces existing password",
+			dsn:      "postgres://gopodder:oldpass@host:5432/db",
+			password: "newpass",
+			want:     "postgres://gopodder:newpass@host:5432/db",
+		},
+		{
+			name:     "password with special characters is escaped",
+			dsn:      "postgres://user@host:5432/db",
+			password: "p@ss:w/rd",
+			want:     "postgres://user:p%40ss%3Aw%2Frd@host:5432/db",
+		},
+		{
+			name:     "password with no user in dsn",
+			dsn:      "postgres://host:5432/db",
+			password: "secret",
+			want:     "postgres://:secret@host:5432/db",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildPostgresDSN(tt.dsn, tt.password)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("buildPostgresDSN() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("buildPostgresDSN() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestOpenStore_SQLite(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")


### PR DESCRIPTION
## Summary

- Adds `GOPODDER_DB_POSTGRES_PASSWORD` env var (and `--db-postgres-password` flag) to pass the PostgreSQL password separately from the connection string, enabling use with container secret managers like Podman Secrets
- Adds `env:"GOPODDER_..."` tags to all existing CLI flags for container-friendly deployments
- Password is securely injected into the connection URL at startup, with proper escaping of special characters

## Example usage (Podman Quadlet)

```ini
Environment=GOPODDER_DB_POSTGRES=postgres://gopodder@pg_server:5432/gopodder
Secret=gopodder_db_pass,type=env,target=GOPODDER_DB_POSTGRES_PASSWORD
```

## Environment variables

| Variable | Flag | Description |
|----------|------|-------------|
| `GOPODDER_LOG_LEVEL` | `--log-level` | Log level |
| `GOPODDER_LISTEN_ADDRESS` | `--listen-address` | HTTP listen address |
| `GOPODDER_DEBUG_ADDRESS` | `--debug-address` | Debug/metrics address |
| `GOPODDER_DB_BACKEND` | `--db-backend` | Database backend |
| `GOPODDER_DB_PATH` | `--db-path` | SQLite database path |
| `GOPODDER_DB_POSTGRES` | `--db-postgres` | PostgreSQL connection string |
| `GOPODDER_DB_POSTGRES_PASSWORD` | `--db-postgres-password` | PostgreSQL password (injected into connection string) |

## Test plan

- [x] Unit tests for `buildPostgresDSN` covering: empty password, password injection, password replacement, special character escaping, missing user
- [x] Full test suite passes
- [x] Build succeeds

Closes #20