### PR TITLE
fix(auth): reject passwords over bcrypt's 72 byte limit

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -112,7 +112,7 @@ POST /api/v1/users
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `username` | string | yes | 1-64 characters, letters/numbers/dots/dashes/underscores |
-| `password` | string | yes | Must meet the instance's minimum password length |
+| `password` | string | yes | Must meet the instance's minimum password length, and at most 72 bytes (bcrypt limit) |
 
 **Response (201):**
 
@@ -122,7 +122,7 @@ POST /api/v1/users
 
 **Errors:**
 
-- `400` — Invalid username or password too short
+- `400` — Invalid username, or password too short or longer than 72 bytes
 - `403` — User creation is disabled, or user limit reached
 - `409` — Username already exists
 
@@ -358,7 +358,7 @@ POST /api/v1/accounts
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `username` | string | yes | 1-64 characters |
-| `password` | string | yes | Must meet minimum password length |
+| `password` | string | yes | Must meet minimum password length, and at most 72 bytes (bcrypt limit) |
 | `role` | string | no | `standard` (default) or `admin` |
 
 **Response (201):**

--- a/gopodder/api_devices_test.go
+++ b/gopodder/api_devices_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestHandleListDevices(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	store.devices["testuser"] = []Device{
 		{ID: "phone1", Caption: "My Phone", Type: "mobile"},
 	}
@@ -41,7 +41,7 @@ func TestHandleListDevices(t *testing.T) {
 
 func TestHandleListDevices_Empty(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	api := newTestAPI(store)
 	handler := api.Handler()
 
@@ -64,7 +64,7 @@ func TestHandleListDevices_Empty(t *testing.T) {
 
 func TestHandleListDevices_Forbidden(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	api := newTestAPI(store)
 	handler := api.Handler()
 
@@ -79,7 +79,7 @@ func TestHandleListDevices_Forbidden(t *testing.T) {
 
 func TestHandleUpdateDevice(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	api := newTestAPI(store)
 	handler := api.Handler()
 
@@ -142,7 +142,7 @@ func TestHandleUpdateDevice(t *testing.T) {
 
 func TestHandleUpdateDevice_PersistsData(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	api := newTestAPI(store)
 	handler := api.Handler()
 

--- a/gopodder/api_episodes_test.go
+++ b/gopodder/api_episodes_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestHandleGetEpisodes(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	device := "phone1"
 	store.episodes["testuser"] = []Episode{
 		{Podcast: "http://pod.com/feed", Episode: "http://pod.com/ep1.mp3", Device: &device, Action: "play"},
@@ -46,7 +46,7 @@ func TestHandleGetEpisodes(t *testing.T) {
 
 	t.Run("empty episodes returns empty array not null", func(t *testing.T) {
 		store2 := newMockStore()
-		store2.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+		store2.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 		api2 := newTestAPI(store2)
 		handler2 := api2.Handler()
 
@@ -113,7 +113,7 @@ func TestHandleGetEpisodes(t *testing.T) {
 
 func TestHandleUploadEpisodes(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	api := newTestAPI(store)
 	handler := api.Handler()
 

--- a/gopodder/api_keys.go
+++ b/gopodder/api_keys.go
@@ -172,7 +172,7 @@ func (a *API) handleAPICreateUser(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid username"})
 		return
 	}
-	if msg := a.checkMinPasswordLength(r.Context(), req.Password); msg != "" {
+	if msg := a.checkPasswordLength(r.Context(), req.Password); msg != "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": msg})
 		return
 	}
@@ -188,7 +188,13 @@ func (a *API) handleAPICreateUser(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": "username already exists"})
 		return
 	}
-	if err := a.store.CreateUser(r.Context(), req.Username, hashPassword(req.Password), acct.ID); err != nil {
+	pwhash, err := hashPassword(req.Password)
+	if err != nil {
+		a.logger.Error("failed to hash password", "err", err, "username", req.Username)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create user"})
+		return
+	}
+	if err := a.store.CreateUser(r.Context(), req.Username, pwhash, acct.ID); err != nil {
 		a.logger.Error("failed to create user", "err", err, "username", req.Username)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create user"})
 		return
@@ -207,12 +213,15 @@ func (a *API) userCreationAllowed(ctx context.Context, acct *Account) bool {
 	return val == "true"
 }
 
-func (a *API) checkMinPasswordLength(ctx context.Context, password string) string {
+func (a *API) checkPasswordLength(ctx context.Context, password string) string {
 	val, _ := a.store.GetSetting(ctx, SettingMinPasswordLength)
 	minLen, _ := strconv.ParseInt(val, 10, 64)
 	minLen = cmp.Or(minLen, 8)
 	if int64(len(password)) < minLen {
 		return fmt.Sprintf("password must be at least %d characters", minLen)
+	}
+	if len(password) > maxPasswordBytes {
+		return fmt.Sprintf("password must be at most %d bytes long", maxPasswordBytes)
 	}
 	return ""
 }
@@ -412,7 +421,7 @@ func (a *API) handleAPICreateAccount(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid username"})
 		return
 	}
-	if msg := a.checkMinPasswordLength(r.Context(), req.Password); msg != "" {
+	if msg := a.checkPasswordLength(r.Context(), req.Password); msg != "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": msg})
 		return
 	}
@@ -424,8 +433,14 @@ func (a *API) handleAPICreateAccount(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": "account already exists"})
 		return
 	}
+	pwhash, err := hashPassword(req.Password)
+	if err != nil {
+		a.logger.Error("failed to hash password", "err", err, "username", req.Username)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create account"})
+		return
+	}
 	id := uuid.New().String()
-	if err := a.store.CreateAccount(r.Context(), id, req.Username, hashPassword(req.Password), req.Role, time.Now()); err != nil {
+	if err := a.store.CreateAccount(r.Context(), id, req.Username, pwhash, req.Role, time.Now()); err != nil {
 		a.logger.Error("failed to create account", "err", err, "username", req.Username)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create account"})
 		return

--- a/gopodder/api_keys_test.go
+++ b/gopodder/api_keys_test.go
@@ -358,12 +358,34 @@ func TestAPIv1_AdminCreateAccount(t *testing.T) {
 	}
 }
 
+func TestAPIv1_AdminCreateAccount_PasswordTooLong(t *testing.T) {
+	store := newMockStore()
+	api := newTestAPI(store)
+	handler := api.Handler()
+
+	token := "gp_aabbccdd11223344aabbccdd11223344"
+	seedAPIKey(store, "admin-id", RoleAdmin, token)
+
+	w := httptest.NewRecorder()
+	body := `{"username":"longpw","password":"` + strings.Repeat("a", 100) + `","role":"standard"}`
+	handler.ServeHTTP(w, bearerRequest("POST", "/api/v1/accounts", token, body))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	for _, a := range store.accounts {
+		if a.Username == "longpw" {
+			t.Fatal("account should not have been created")
+		}
+	}
+}
+
 func TestAPIv1_AdminDeleteAccount(t *testing.T) {
 	store := newMockStore()
 	api := newTestAPI(store)
 	handler := api.Handler()
 
-	store.accounts["target-id"] = &Account{ID: "target-id", Username: "target", PWHash: hashPassword("pass"), Role: RoleStandard}
+	store.accounts["target-id"] = &Account{ID: "target-id", Username: "target", PWHash: testHash("pass"), Role: RoleStandard}
 
 	token := "gp_aabbccdd11223344aabbccdd11223344"
 	seedAPIKey(store, "admin-id", RoleAdmin, token)
@@ -462,6 +484,29 @@ func TestAPIv1_CreateUser_PasswordTooShort(t *testing.T) {
 	}
 }
 
+func TestAPIv1_CreateUser_PasswordTooLong(t *testing.T) {
+	store := newMockStore()
+	api := newTestAPI(store)
+	handler := api.Handler()
+
+	token := "gp_aabbccdd11223344aabbccdd11223344"
+	seedAPIKey(store, "admin-id", RoleStandard, token)
+
+	w := httptest.NewRecorder()
+	body := `{"username":"longpw","password":"` + strings.Repeat("a", 100) + `"}`
+	handler.ServeHTTP(w, bearerRequest("POST", "/api/v1/users", token, body))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "72") {
+		t.Errorf("expected password length error mentioning the byte limit, got: %s", w.Body.String())
+	}
+	if _, err := store.GetUser(t.Context(), "longpw"); err == nil {
+		t.Error("user should not have been created")
+	}
+}
+
 func TestAPIv1_CreateUser_LimitReached(t *testing.T) {
 	store := newMockStore()
 	api := newTestAPI(store)
@@ -513,7 +558,7 @@ func TestAPIv1_CreateUser_CreationDisabled(t *testing.T) {
 	handler := api.Handler()
 
 	store.settings["allow_user_creation"] = "false"
-	store.accounts["std-id"] = &Account{ID: "std-id", Username: "stduser", PWHash: hashPassword("pass"), Role: RoleStandard}
+	store.accounts["std-id"] = &Account{ID: "std-id", Username: "stduser", PWHash: testHash("pass"), Role: RoleStandard}
 
 	token := "gp_bbccddee11223344aabbccdd11223344"
 	seedAPIKey(store, "std-id", RoleStandard, token)
@@ -697,7 +742,7 @@ func TestAPIv1_AdminCannotDeleteOtherAdmin(t *testing.T) {
 	api := newTestAPI(store)
 	handler := api.Handler()
 
-	store.accounts["other-admin"] = &Account{ID: "other-admin", Username: "otheradmin", PWHash: hashPassword("pass"), Role: RoleAdmin}
+	store.accounts["other-admin"] = &Account{ID: "other-admin", Username: "otheradmin", PWHash: testHash("pass"), Role: RoleAdmin}
 
 	token := "gp_aabbccdd11223344aabbccdd11223344"
 	seedAPIKey(store, "admin-id", RoleAdmin, token)

--- a/gopodder/api_subscriptions_test.go
+++ b/gopodder/api_subscriptions_test.go
@@ -36,7 +36,7 @@ func TestHasOverlap(t *testing.T) {
 
 func TestHandleGetSubscriptions(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	store.subscriptions["testuser"] = []string{"http://a.com/feed", "http://b.com/feed"}
 	api := newTestAPI(store)
 	handler := api.Handler()
@@ -61,7 +61,7 @@ func TestHandleGetSubscriptions(t *testing.T) {
 
 	t.Run("empty user returns empty array not null", func(t *testing.T) {
 		store2 := newMockStore()
-		store2.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+		store2.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 		api2 := newTestAPI(store2)
 		handler2 := api2.Handler()
 
@@ -91,7 +91,7 @@ func TestHandleGetSubscriptions(t *testing.T) {
 
 func TestHandleGetAllSubscriptions(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	store.subscriptions["testuser"] = []string{"http://a.com/feed", "http://b.com/feed", "http://c.com/feed"}
 	api := newTestAPI(store)
 	handler := api.Handler()
@@ -116,7 +116,7 @@ func TestHandleGetAllSubscriptions(t *testing.T) {
 
 	t.Run("empty returns empty array", func(t *testing.T) {
 		store2 := newMockStore()
-		store2.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+		store2.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 		api2 := newTestAPI(store2)
 		handler2 := api2.Handler()
 
@@ -146,7 +146,7 @@ func TestHandleGetAllSubscriptions(t *testing.T) {
 
 func TestHandleUploadSubscriptions(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	store.subscriptions["testuser"] = []string{"http://old.com/feed"}
 	api := newTestAPI(store)
 	handler := api.Handler()
@@ -202,7 +202,7 @@ func TestHandleUploadSubscriptions(t *testing.T) {
 
 func TestHandleUploadSubscriptionChanges(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	api := newTestAPI(store)
 	handler := api.Handler()
 
@@ -263,7 +263,7 @@ func TestHandleUploadSubscriptionChanges(t *testing.T) {
 
 func TestHandleUploadSubscriptionChanges_UnmatchedRemoval(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	store.subscriptions["testuser"] = []string{"http://a.com", "http://b.com"}
 	api := newTestAPI(store)
 	handler := api.Handler()
@@ -317,7 +317,7 @@ func TestHandleUploadSubscriptionChanges_UnmatchedRemoval(t *testing.T) {
 
 func TestHandleUploadSubscriptionChanges_TimestampAdvances(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	api := newTestAPI(store)
 	handler := api.Handler()
 
@@ -343,7 +343,7 @@ func TestHandleUploadSubscriptionChanges_TimestampAdvances(t *testing.T) {
 
 func TestHandleGetSubscriptionChanges_TimestampAdvances(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	api := newTestAPI(store)
 	handler := api.Handler()
 
@@ -368,7 +368,7 @@ func TestHandleGetSubscriptionChanges_TimestampAdvances(t *testing.T) {
 
 func TestHandleGetSubscriptionChanges(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	api := newTestAPI(store)
 	handler := api.Handler()
 

--- a/gopodder/api_test.go
+++ b/gopodder/api_test.go
@@ -294,7 +294,7 @@ func TestHandleEmptyJSON(t *testing.T) {
 
 func TestHandleGetAllSubscriptions_OPML(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	store.subscriptions["testuser"] = []string{"https://example.com/feed.xml"}
 	api := newTestAPI(store)
 	handler := api.Handler()

--- a/gopodder/auth.go
+++ b/gopodder/auth.go
@@ -15,6 +15,10 @@ type contextKey string
 
 const contextKeyUsername contextKey = "username"
 
+// maxPasswordBytes is the hard input limit of bcrypt. Longer passwords are
+// rejected during validation so they can never reach the hashing step.
+const maxPasswordBytes = 72
+
 func UsernameFromContext(ctx context.Context) string {
 	if v, ok := ctx.Value(contextKeyUsername).(string); ok {
 		return v
@@ -128,9 +132,15 @@ func extractSessionCookie(r *http.Request) string {
 	return cookie.Value
 }
 
-func hashPassword(password string) string {
-	hash, _ := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	return string(hash)
+// hashPassword hashes a password with bcrypt. It fails for passwords longer
+// than maxPasswordBytes; callers must not store the returned hash on error, or
+// the account ends up with an empty hash and nobody can log into it.
+func hashPassword(password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hash), nil
 }
 
 func checkPassword(hash, password string) bool {

--- a/gopodder/auth_test.go
+++ b/gopodder/auth_test.go
@@ -5,13 +5,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 )
 
 func TestHashPassword(t *testing.T) {
 	t.Run("produces bcrypt hash", func(t *testing.T) {
-		got := hashPassword("testpass")
+		got, err := hashPassword("testpass")
+		if err != nil {
+			t.Fatalf("hashPassword returned error: %v", err)
+		}
 		if got == "" {
 			t.Error("hashPassword returned empty string")
 		}
@@ -21,7 +25,7 @@ func TestHashPassword(t *testing.T) {
 	})
 
 	t.Run("checkPassword verifies correctly", func(t *testing.T) {
-		hash := hashPassword("hello")
+		hash := testHash("hello")
 		if !checkPassword(hash, "hello") {
 			t.Error("checkPassword should return true for correct password")
 		}
@@ -31,10 +35,30 @@ func TestHashPassword(t *testing.T) {
 	})
 
 	t.Run("different calls produce different hashes", func(t *testing.T) {
-		a := hashPassword("hello")
-		b := hashPassword("hello")
+		a := testHash("hello")
+		b := testHash("hello")
 		if a == b {
 			t.Error("bcrypt should produce different hashes due to random salt")
+		}
+	})
+
+	t.Run("accepts password at the bcrypt limit", func(t *testing.T) {
+		got, err := hashPassword(strings.Repeat("a", 72))
+		if err != nil {
+			t.Fatalf("hashPassword returned error for 72-byte password: %v", err)
+		}
+		if got == "" {
+			t.Error("hashPassword returned empty string for 72-byte password")
+		}
+	})
+
+	t.Run("reports an error instead of an empty hash for oversized passwords", func(t *testing.T) {
+		got, err := hashPassword(strings.Repeat("a", 73))
+		if err == nil {
+			t.Fatal("hashPassword should report an error for a 73-byte password")
+		}
+		if got != "" {
+			t.Errorf("hashPassword should return an empty hash on error, got %q", got)
 		}
 	})
 }
@@ -137,7 +161,7 @@ func TestHandleLogin(t *testing.T) {
 	store := newMockStore()
 	store.users["testuser"] = &User{
 		Username: "testuser",
-		PWHash:   hashPassword("testpass"),
+		PWHash:   testHash("testpass"),
 	}
 	api := newTestAPI(store)
 	handler := api.Handler()
@@ -200,7 +224,7 @@ func TestHandleLogin_RotatesSession(t *testing.T) {
 	sid := "old-session-123"
 	store.users["testuser"] = &User{
 		Username:  "testuser",
-		PWHash:    hashPassword("testpass"),
+		PWHash:    testHash("testpass"),
 		SessionID: &sid,
 	}
 	api := newTestAPI(store)
@@ -243,7 +267,7 @@ func TestHandleLogout(t *testing.T) {
 	now := time.Now()
 	store.users["testuser"] = &User{
 		Username:       "testuser",
-		PWHash:         hashPassword("testpass"),
+		PWHash:         testHash("testpass"),
 		SessionID:      &sid,
 		SessionCreated: &now,
 	}
@@ -286,7 +310,7 @@ func TestSessionBasedAuth(t *testing.T) {
 	now := time.Now()
 	store.users["testuser"] = &User{
 		Username:       "testuser",
-		PWHash:         hashPassword("testpass"),
+		PWHash:         testHash("testpass"),
 		SessionID:      &sid,
 		SessionCreated: &now,
 	}
@@ -332,7 +356,7 @@ func TestSessionBasedAuth(t *testing.T) {
 
 func TestRouteAuth_InvalidPaths(t *testing.T) {
 	store := newMockStore()
-	store.users["testuser"] = &User{Username: "testuser", PWHash: hashPassword("testpass")}
+	store.users["testuser"] = &User{Username: "testuser", PWHash: testHash("testpass")}
 	api := newTestAPI(store)
 	handler := api.Handler()
 

--- a/gopodder/helpers_test.go
+++ b/gopodder/helpers_test.go
@@ -435,9 +435,19 @@ func (m *mockStore) SetSetting(_ context.Context, key, value string) error {
 func (m *mockStore) Ping(_ context.Context) error { return nil }
 func (m *mockStore) Close() error                  { return nil }
 
+// testHash hashes a fixture password, panicking on the errors that can only
+// come from a malformed test fixture.
+func testHash(password string) string {
+	hash, err := hashPassword(password)
+	if err != nil {
+		panic(err)
+	}
+	return hash
+}
+
 func newTestAPI(store Store) *API {
 	if ms, ok := store.(*mockStore); ok {
-		ms.accounts["admin-id"] = &Account{ID: "admin-id", Username: "admin", PWHash: hashPassword("admin"), Role: RoleAdmin}
+		ms.accounts["admin-id"] = &Account{ID: "admin-id", Username: "admin", PWHash: testHash("admin"), Role: RoleAdmin}
 	}
 	logger := slog.Default()
 	return NewAPI(logger, store, noopMetrics{}, BuildInfo{

--- a/gopodder/store_sqlite_test.go
+++ b/gopodder/store_sqlite_test.go
@@ -25,7 +25,7 @@ func TestSQLiteStore_CreateAndGetUser(t *testing.T) {
 	store := newTestStore(t)
 	ctx := t.Context()
 
-	pwhash := hashPassword("secret")
+	pwhash := testHash("secret")
 	if err := store.CreateUser(ctx, "alice", pwhash, testAccountID); err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestSQLiteStore_SessionManagement(t *testing.T) {
 	store := newTestStore(t)
 	ctx := t.Context()
 
-	if err := store.CreateUser(ctx, "bob", hashPassword("pass"), testAccountID); err != nil {
+	if err := store.CreateUser(ctx, "bob", testHash("pass"), testAccountID); err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
 
@@ -1582,7 +1582,7 @@ func TestSQLiteStore_ShareToken(t *testing.T) {
 	store := newTestStore(t)
 	ctx := t.Context()
 
-	if err := store.CreateUser(ctx, "alice", hashPassword("pass"), testAccountID); err != nil {
+	if err := store.CreateUser(ctx, "alice", testHash("pass"), testAccountID); err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
 
@@ -1694,7 +1694,7 @@ func TestSQLiteStore_DeleteEpisodesOlderThan(t *testing.T) {
 	store := newTestStore(t)
 	ctx := t.Context()
 
-	if err := store.CreateUser(ctx, "alice", hashPassword("pass"), testAccountID); err != nil {
+	if err := store.CreateUser(ctx, "alice", testHash("pass"), testAccountID); err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
 
@@ -2019,8 +2019,8 @@ func TestSQLiteStore_UsersCRUD(t *testing.T) {
 	store := newTestStore(t)
 	ctx := t.Context()
 
-	_ = store.CreateUser(ctx, "alice", hashPassword("pass"), testAccountID)
-	_ = store.CreateUser(ctx, "bob", hashPassword("pass"), testAccountID)
+	_ = store.CreateUser(ctx, "alice", testHash("pass"), testAccountID)
+	_ = store.CreateUser(ctx, "bob", testHash("pass"), testAccountID)
 
 	t.Run("list all users", func(t *testing.T) {
 		users, err := store.ListUsers(ctx)

--- a/gopodder/web_handler.go
+++ b/gopodder/web_handler.go
@@ -178,13 +178,14 @@ func (h *WebHandler) handleSetupSubmit(w http.ResponseWriter, r *http.Request) {
 		_ = web.SetupPage("Passwords do not match.").Render(r.Context(), w)
 		return
 	}
-	if msg := h.checkPasswordLength(r.Context(), password); msg != "" {
+	pwhash, msg := h.hashNewPassword(r.Context(), password)
+	if msg != "" {
 		_ = web.SetupPage(msg).Render(r.Context(), w)
 		return
 	}
 
 	id := uuid.New().String()
-	if err := h.store.CreateAccount(r.Context(), id, username, hashPassword(password), RoleAdmin, time.Now()); err != nil {
+	if err := h.store.CreateAccount(r.Context(), id, username, pwhash, RoleAdmin, time.Now()); err != nil {
 		h.logger.Error("failed to create initial admin account", "err", err)
 		_ = web.SetupPage("Failed to create account.").Render(r.Context(), w)
 		return
@@ -302,11 +303,12 @@ func (h *WebHandler) handleSelfChangeAccountPassword(w http.ResponseWriter, r *h
 		http.Redirect(w, r, "/account?error=New+passwords+do+not+match.", http.StatusSeeOther)
 		return
 	}
-	if msg := h.checkPasswordLength(r.Context(), password); msg != "" {
+	pwhash, msg := h.hashNewPassword(r.Context(), password)
+	if msg != "" {
 		http.Redirect(w, r, "/account?error="+msg, http.StatusSeeOther)
 		return
 	}
-	_ = h.store.UpdateAccountPassword(r.Context(), acct.ID, hashPassword(password))
+	_ = h.store.UpdateAccountPassword(r.Context(), acct.ID, pwhash)
 	http.Redirect(w, r, "/account?flash=Password+updated.", http.StatusSeeOther)
 }
 
@@ -458,7 +460,8 @@ func (h *WebHandler) handleSelfCreateUser(w http.ResponseWriter, r *http.Request
 		http.Redirect(w, r, "/users?error=Username+must+be+1-64+characters+using+only+letters,+numbers,+dots,+dashes,+or+underscores.", http.StatusSeeOther)
 		return
 	}
-	if msg := h.checkPasswordLength(r.Context(), password); msg != "" {
+	pwhash, msg := h.hashNewPassword(r.Context(), password)
+	if msg != "" {
 		http.Redirect(w, r, "/users?error="+msg, http.StatusSeeOther)
 		return
 	}
@@ -466,7 +469,7 @@ func (h *WebHandler) handleSelfCreateUser(w http.ResponseWriter, r *http.Request
 		http.Redirect(w, r, "/users?error=Username+already+exists.+Please+choose+a+different+name.", http.StatusSeeOther)
 		return
 	}
-	if err := h.store.CreateUser(r.Context(), username, hashPassword(password), acct.ID); err != nil {
+	if err := h.store.CreateUser(r.Context(), username, pwhash, acct.ID); err != nil {
 		h.logger.Error("failed to create gpodder user", "err", err, "username", username, "account", acct.Username)
 		http.Redirect(w, r, "/users?error=Failed+to+create+user.", http.StatusSeeOther)
 		return
@@ -487,11 +490,12 @@ func (h *WebHandler) handleSelfChangeUserPassword(w http.ResponseWriter, r *http
 		http.Redirect(w, r, "/users/"+username+"?error=Passwords+do+not+match.", http.StatusSeeOther)
 		return
 	}
-	if msg := h.checkPasswordLength(r.Context(), password); msg != "" {
+	pwhash, msg := h.hashNewPassword(r.Context(), password)
+	if msg != "" {
 		http.Redirect(w, r, "/users/"+username+"?error="+msg, http.StatusSeeOther)
 		return
 	}
-	if err := h.store.UpdateUserPassword(r.Context(), username, hashPassword(password)); err != nil {
+	if err := h.store.UpdateUserPassword(r.Context(), username, pwhash); err != nil {
 		h.logger.Error("failed to update gpodder user password", "err", err, "username", username)
 	}
 	http.Redirect(w, r, "/users/"+username+"?flash=Password+updated.", http.StatusSeeOther)
@@ -816,7 +820,8 @@ func (h *WebHandler) handleCreateAccount(w http.ResponseWriter, r *http.Request)
 		http.Redirect(w, r, "/admin/accounts?error=Username+must+be+1-64+characters+using+only+letters,+numbers,+dots,+dashes,+or+underscores.", http.StatusSeeOther)
 		return
 	}
-	if msg := h.checkPasswordLength(r.Context(), password); msg != "" {
+	pwhash, msg := h.hashNewPassword(r.Context(), password)
+	if msg != "" {
 		http.Redirect(w, r, "/admin/accounts?error="+msg, http.StatusSeeOther)
 		return
 	}
@@ -828,7 +833,7 @@ func (h *WebHandler) handleCreateAccount(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	id := uuid.New().String()
-	if err := h.store.CreateAccount(r.Context(), id, username, hashPassword(password), role, time.Now()); err != nil {
+	if err := h.store.CreateAccount(r.Context(), id, username, pwhash, role, time.Now()); err != nil {
 		h.logger.Error("failed to create account", "err", err, "username", username)
 		http.Redirect(w, r, "/admin/accounts?error=Failed+to+create+account.", http.StatusSeeOther)
 		return
@@ -867,11 +872,12 @@ func (h *WebHandler) handleChangeAccountPassword(w http.ResponseWriter, r *http.
 		http.Redirect(w, r, "/admin/accounts/"+id+"?error=Passwords+do+not+match.", http.StatusSeeOther)
 		return
 	}
-	if msg := h.checkPasswordLength(r.Context(), password); msg != "" {
+	pwhash, msg := h.hashNewPassword(r.Context(), password)
+	if msg != "" {
 		http.Redirect(w, r, "/admin/accounts/"+id+"?error="+msg, http.StatusSeeOther)
 		return
 	}
-	_ = h.store.UpdateAccountPassword(r.Context(), id, hashPassword(password))
+	_ = h.store.UpdateAccountPassword(r.Context(), id, pwhash)
 	http.Redirect(w, r, "/admin/accounts/"+id+"?flash=Password+updated.", http.StatusSeeOther)
 }
 
@@ -929,11 +935,12 @@ func (h *WebHandler) handleChangeUserPassword(w http.ResponseWriter, r *http.Req
 		http.Redirect(w, r, redirect+"?error=Passwords+do+not+match.", http.StatusSeeOther)
 		return
 	}
-	if msg := h.checkPasswordLength(r.Context(), password); msg != "" {
+	pwhash, msg := h.hashNewPassword(r.Context(), password)
+	if msg != "" {
 		http.Redirect(w, r, redirect+"?error="+msg, http.StatusSeeOther)
 		return
 	}
-	if err := h.store.UpdateUserPassword(r.Context(), username, hashPassword(password)); err != nil {
+	if err := h.store.UpdateUserPassword(r.Context(), username, pwhash); err != nil {
 		h.logger.Error("failed to update gpodder user password", "err", err, "username", username)
 	}
 	http.Redirect(w, r, redirect+"?flash=Password+updated.", http.StatusSeeOther)
@@ -951,7 +958,8 @@ func (h *WebHandler) handleCreateUser(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/admin/accounts/"+accountID+"?error=Username+must+be+1-64+characters+using+only+letters,+numbers,+dots,+dashes,+or+underscores.", http.StatusSeeOther)
 		return
 	}
-	if msg := h.checkPasswordLength(r.Context(), password); msg != "" {
+	pwhash, msg := h.hashNewPassword(r.Context(), password)
+	if msg != "" {
 		http.Redirect(w, r, "/admin/accounts/"+accountID+"?error="+msg, http.StatusSeeOther)
 		return
 	}
@@ -963,7 +971,7 @@ func (h *WebHandler) handleCreateUser(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/admin/accounts/"+accountID+"?error=Username+already+exists.+Please+choose+a+different+name.", http.StatusSeeOther)
 		return
 	}
-	if err := h.store.CreateUser(r.Context(), username, hashPassword(password), accountID); err != nil {
+	if err := h.store.CreateUser(r.Context(), username, pwhash, accountID); err != nil {
 		h.logger.Error("failed to create gpodder user", "err", err, "username", username)
 		http.Redirect(w, r, "/admin/accounts/"+accountID+"?error=Failed+to+create+user.", http.StatusSeeOther)
 		return
@@ -1063,7 +1071,8 @@ func (h *WebHandler) handleRegisterSubmit(w http.ResponseWriter, r *http.Request
 		_ = web.RegisterPage(web.RegisterPageData{Error: "Passwords do not match."}).Render(r.Context(), w)
 		return
 	}
-	if msg := h.checkPasswordLength(r.Context(), password); msg != "" {
+	pwhash, msg := h.hashNewPassword(r.Context(), password)
+	if msg != "" {
 		_ = web.RegisterPage(web.RegisterPageData{Error: msg}).Render(r.Context(), w)
 		return
 	}
@@ -1074,7 +1083,7 @@ func (h *WebHandler) handleRegisterSubmit(w http.ResponseWriter, r *http.Request
 	}
 
 	id := uuid.New().String()
-	if err := h.store.CreateAccount(r.Context(), id, username, hashPassword(password), RoleStandard, time.Now()); err != nil {
+	if err := h.store.CreateAccount(r.Context(), id, username, pwhash, RoleStandard, time.Now()); err != nil {
 		h.logger.Error("failed to create self-registered account", "err", err, "username", username)
 		_ = web.RegisterPage(web.RegisterPageData{Error: "Failed to create account."}).Render(r.Context(), w)
 		return
@@ -1177,7 +1186,25 @@ func (h *WebHandler) checkPasswordLength(ctx context.Context, password string) s
 	if int64(len(password)) < minLen {
 		return fmt.Sprintf("Password must be at least %d characters.", minLen)
 	}
+	if len(password) > maxPasswordBytes {
+		return fmt.Sprintf("Password must be at most %d bytes long.", maxPasswordBytes)
+	}
 	return ""
+}
+
+// hashNewPassword validates and hashes a password chosen by a user. It returns
+// either a usable hash or a message to show the user, never both empty, so a
+// rejected password can never be stored as an empty hash.
+func (h *WebHandler) hashNewPassword(ctx context.Context, password string) (hash, errMsg string) {
+	if msg := h.checkPasswordLength(ctx, password); msg != "" {
+		return "", msg
+	}
+	hash, err := hashPassword(password)
+	if err != nil {
+		h.logger.Error("failed to hash password", "err", err)
+		return "", "Failed to process password."
+	}
+	return hash, ""
 }
 
 func (h *WebHandler) userLimitReached(ctx context.Context, accountID string) bool {

--- a/gopodder/web_handler_test.go
+++ b/gopodder/web_handler_test.go
@@ -241,7 +241,7 @@ func TestWithAdmin_NonAdmin(t *testing.T) {
 	store := newMockStore()
 	api := newTestAPI(store)
 	sid := "user-session"
-	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("pass"), Role: RoleStandard, SessionID: &sid}
+	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("pass"), Role: RoleStandard, SessionID: &sid}
 	h := NewWebHandler(api)
 
 	called := false
@@ -570,7 +570,7 @@ func TestHandleSelfCreateUser_Disabled(t *testing.T) {
 	store.settings["allow_user_creation"] = "false"
 	api := newTestAPI(store)
 	sid := "user-session"
-	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("pass"), Role: RoleStandard, SessionID: &sid}
+	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("pass"), Role: RoleStandard, SessionID: &sid}
 	h := NewWebHandler(api)
 
 	r := httptest.NewRequest(http.MethodPost, "/users", strings.NewReader("username=gpuser1&password=testpass1"))
@@ -597,7 +597,7 @@ func TestHandleSelfCreateUser_Enabled(t *testing.T) {
 	store.settings[SettingAllowUserCreation] = "true"
 	api := newTestAPI(store)
 	sid := "user-session"
-	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("pass"), Role: RoleStandard, SessionID: &sid}
+	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("pass"), Role: RoleStandard, SessionID: &sid}
 	h := NewWebHandler(api)
 
 	r := httptest.NewRequest(http.MethodPost, "/users", strings.NewReader("username=gpuser1&password=testpass1"))
@@ -743,7 +743,7 @@ func TestHandleSelfCreateUser_LimitReached(t *testing.T) {
 	store.settings[SettingMaxUsersPerAccount] = "1"
 	api := newTestAPI(store)
 	sid := "user-session"
-	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("pass"), Role: RoleStandard, SessionID: &sid}
+	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("pass"), Role: RoleStandard, SessionID: &sid}
 	store.users["existing"] = &User{Username: "existing", AccountID: "u1"}
 	h := NewWebHandler(api)
 
@@ -831,6 +831,32 @@ func TestCheckPasswordLength(t *testing.T) {
 			t.Errorf("expected empty for long password, got %q", msg)
 		}
 	})
+
+	t.Run("password exactly at bcrypt limit", func(t *testing.T) {
+		store.settings[SettingMinPasswordLength] = "8"
+		if msg := h.checkPasswordLength(t.Context(), strings.Repeat("a", 72)); msg != "" {
+			t.Errorf("expected empty for 72-byte password, got %q", msg)
+		}
+	})
+
+	t.Run("password over bcrypt limit", func(t *testing.T) {
+		store.settings[SettingMinPasswordLength] = "8"
+		msg := h.checkPasswordLength(t.Context(), strings.Repeat("a", 73))
+		if msg == "" {
+			t.Fatal("expected error for 73-byte password")
+		}
+		if !strings.Contains(msg, "72") {
+			t.Errorf("error should mention the byte limit, got %q", msg)
+		}
+	})
+
+	t.Run("multi-byte password over bcrypt limit", func(t *testing.T) {
+		store.settings[SettingMinPasswordLength] = "8"
+		// 40 runes, 80 bytes: under any sane rune limit, over the bcrypt one.
+		if msg := h.checkPasswordLength(t.Context(), strings.Repeat("ä", 40)); msg == "" {
+			t.Error("expected error for password exceeding 72 bytes in UTF-8")
+		}
+	})
 }
 
 func TestHandleRegisterSubmit_PasswordTooShort(t *testing.T) {
@@ -853,13 +879,55 @@ func TestHandleRegisterSubmit_PasswordTooShort(t *testing.T) {
 	}
 }
 
+func TestHandleRegisterSubmit_PasswordTooLong(t *testing.T) {
+	store := newMockStore()
+	store.settings[SettingSelfRegistration] = "true"
+	api := newTestAPI(store)
+	h := NewWebHandler(api)
+
+	long := strings.Repeat("a", 100)
+	body := "username=newuser&password=" + long + "&password2=" + long
+	r := httptest.NewRequest(http.MethodPost, "/register", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.handleRegisterSubmit(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (renders error page)", w.Code, http.StatusOK)
+	}
+	if len(store.accounts) != 1 {
+		t.Error("account should not have been created")
+	}
+}
+
+func TestHandleSetupSubmit_PasswordTooLong(t *testing.T) {
+	store := newMockStore()
+	api := newTestAPI(store)
+	h := NewWebHandler(api)
+	clear(store.accounts) // first-run setup only happens with no accounts
+
+	long := strings.Repeat("a", 100)
+	body := "username=admin&password=" + long + "&password2=" + long
+	r := httptest.NewRequest(http.MethodPost, "/setup", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	h.handleSetupSubmit(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (renders error page)", w.Code, http.StatusOK)
+	}
+	if len(store.accounts) != 0 {
+		t.Error("admin account should not have been created")
+	}
+}
+
 func TestHandleSelfCreateUser_PasswordTooShort(t *testing.T) {
 	store := newMockStore()
 	store.settings[SettingAllowUserCreation] = "true"
 	store.settings[SettingMinPasswordLength] = "10"
 	api := newTestAPI(store)
 	sid := "user-session"
-	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("pass"), Role: RoleStandard, SessionID: &sid}
+	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("pass"), Role: RoleStandard, SessionID: &sid}
 	h := NewWebHandler(api)
 
 	r := httptest.NewRequest(http.MethodPost, "/users", strings.NewReader("username=gpuser1&password=short"))
@@ -931,7 +999,7 @@ func TestHandleSelfAccountPage(t *testing.T) {
 	store := newMockStore()
 	api := newTestAPI(store)
 	sid := "user-session"
-	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("pass"), Role: RoleStandard, SessionID: &sid}
+	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("pass"), Role: RoleStandard, SessionID: &sid}
 	handler := api.Handler()
 
 	r := httptest.NewRequest(http.MethodGet, "/account", nil)
@@ -954,7 +1022,7 @@ func TestHandleSelfChangeAccountPassword(t *testing.T) {
 	store := newMockStore()
 	api := newTestAPI(store)
 	sid := "user-session"
-	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("oldpass"), Role: RoleStandard, SessionID: &sid}
+	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("oldpass"), Role: RoleStandard, SessionID: &sid}
 	handler := api.Handler()
 
 	t.Run("wrong current password", func(t *testing.T) {
@@ -1036,7 +1104,7 @@ func TestHandleSelfDeleteAccount(t *testing.T) {
 		store := newMockStore()
 		api := newTestAPI(store)
 		sid := "user-session"
-		store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("pass"), Role: RoleStandard, SessionID: &sid}
+		store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("pass"), Role: RoleStandard, SessionID: &sid}
 		store.users["gpuser1"] = &User{Username: "gpuser1", PWHash: "hash", AccountID: "u1"}
 		store.subscriptions["gpuser1"] = []string{"http://feed.com"}
 		handler := api.Handler()
@@ -1068,7 +1136,7 @@ func TestHandleSelfDeleteAccount(t *testing.T) {
 		store := newMockStore()
 		api := newTestAPI(store)
 		sid := "admin-session"
-		store.accounts["admin-id"] = &Account{ID: "admin-id", Username: "admin", PWHash: hashPassword("admin"), Role: RoleAdmin, SessionID: &sid}
+		store.accounts["admin-id"] = &Account{ID: "admin-id", Username: "admin", PWHash: testHash("admin"), Role: RoleAdmin, SessionID: &sid}
 		handler := api.Handler()
 
 		r := httptest.NewRequest(http.MethodPost, "/account/delete", strings.NewReader(withCSRF("admin-session", "")))
@@ -1094,7 +1162,7 @@ func TestHandleSelfImportOPML(t *testing.T) {
 	store := newMockStore()
 	api := newTestAPI(store)
 	sid := "user-session"
-	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("pass"), Role: RoleStandard, SessionID: &sid}
+	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("pass"), Role: RoleStandard, SessionID: &sid}
 	store.users["gpuser1"] = &User{Username: "gpuser1", PWHash: "hash", AccountID: "u1"}
 	store.devices["gpuser1"] = []Device{{ID: "phone", Type: "mobile"}}
 	handler := api.Handler()
@@ -1132,7 +1200,7 @@ func TestHandleSelfImportOPML(t *testing.T) {
 		store2 := newMockStore()
 		api2 := newTestAPI(store2)
 		sid2 := "user-session"
-		store2.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("pass"), Role: RoleStandard, SessionID: &sid2}
+		store2.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("pass"), Role: RoleStandard, SessionID: &sid2}
 		store2.users["gpuser1"] = &User{Username: "gpuser1", PWHash: "hash", AccountID: "u1"}
 		handler2 := api2.Handler()
 
@@ -1204,7 +1272,7 @@ func TestHandleSelfAddSubscription(t *testing.T) {
 	store := newMockStore()
 	api := newTestAPI(store)
 	sid := "user-session"
-	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("pass"), Role: RoleStandard, SessionID: &sid}
+	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("pass"), Role: RoleStandard, SessionID: &sid}
 	store.users["gpuser1"] = &User{Username: "gpuser1", PWHash: "hash", AccountID: "u1"}
 	store.devices["gpuser1"] = []Device{{ID: "phone", Type: "mobile"}}
 	handler := api.Handler()
@@ -1294,7 +1362,7 @@ func TestHandleSelfDeleteSubscription(t *testing.T) {
 	store := newMockStore()
 	api := newTestAPI(store)
 	sid := "user-session"
-	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("pass"), Role: RoleStandard, SessionID: &sid}
+	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("pass"), Role: RoleStandard, SessionID: &sid}
 	store.users["gpuser1"] = &User{Username: "gpuser1", PWHash: "hash", AccountID: "u1"}
 	store.devices["gpuser1"] = []Device{{ID: "phone", Type: "mobile"}, {ID: "laptop", Type: "desktop"}}
 	store.subscriptions["gpuser1"] = []string{"http://feed1.com", "http://feed2.com", "http://feed3.com"}
@@ -1438,7 +1506,7 @@ func TestHandleCreateAPIKey_LimitEnforced(t *testing.T) {
 	handler := api.Handler()
 
 	sid := "user-session"
-	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("pass"), Role: RoleStandard, SessionID: &sid}
+	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("pass"), Role: RoleStandard, SessionID: &sid}
 	store.settings[SettingAllowAPIKeys] = "true"
 	store.settings[SettingMaxAPIKeys] = "2"
 
@@ -1512,7 +1580,7 @@ func TestHandleCreateAPIKey_ZeroSettingUsesDefault(t *testing.T) {
 	handler := api.Handler()
 
 	sid := "user-session"
-	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: hashPassword("pass"), Role: RoleStandard, SessionID: &sid}
+	store.accounts["u1"] = &Account{ID: "u1", Username: "user1", PWHash: testHash("pass"), Role: RoleStandard, SessionID: &sid}
 	store.settings[SettingAllowAPIKeys] = "true"
 	store.settings[SettingMaxAPIKeys] = "0"
 
@@ -1599,7 +1667,7 @@ func TestSessionExpiry(t *testing.T) {
 	sid := "web-session"
 	expired := time.Now().Add(-200 * time.Hour)
 	store.accounts["u1"] = &Account{
-		ID: "u1", Username: "user1", PWHash: hashPassword("pass"),
+		ID: "u1", Username: "user1", PWHash: testHash("pass"),
 		Role: RoleStandard, SessionID: &sid, SessionCreated: &expired,
 	}
 	handler := api.Handler()
@@ -1637,7 +1705,7 @@ func TestHandlePublicOPML(t *testing.T) {
 	store := newMockStore()
 	store.settings[SettingAllowSharing] = "true"
 	token := "test-share-token"
-	store.users["gpuser1"] = &User{Username: "gpuser1", PWHash: hashPassword("pass"), AccountID: "acct1", ShareToken: &token}
+	store.users["gpuser1"] = &User{Username: "gpuser1", PWHash: testHash("pass"), AccountID: "acct1", ShareToken: &token}
 	store.subscriptions["gpuser1"] = []string{"http://a.com/feed", "http://b.com/feed"}
 	api := NewAPI(nil, store, noopMetrics{}, BuildInfo{}, "localhost:8080", "sqlite")
 	h := NewWebHandler(api)
@@ -1696,7 +1764,7 @@ func TestHandlePublicRSS(t *testing.T) {
 	store := newMockStore()
 	store.settings[SettingAllowSharing] = "true"
 	token := "test-share-token"
-	store.users["gpuser1"] = &User{Username: "gpuser1", PWHash: hashPassword("pass"), AccountID: "acct1", ShareToken: &token}
+	store.users["gpuser1"] = &User{Username: "gpuser1", PWHash: testHash("pass"), AccountID: "acct1", ShareToken: &token}
 	store.subscriptions["gpuser1"] = []string{"http://a.com/feed", "http://b.com/feed"}
 	api := NewAPI(nil, store, noopMetrics{}, BuildInfo{}, "localhost:8080", "sqlite")
 	h := NewWebHandler(api)


### PR DESCRIPTION
## What

- `hashPassword` returns an error instead of swallowing it, so an empty hash can never be stored
- passwords over 72 bytes are rejected during validation, in the web UI and in the v1 API
- tests for the boundary (72/73 bytes, multi-byte input) plus handler tests for setup, registration and both API create endpoints
- APIDOCS notes the limit

Closes #49

## Why

bcrypt takes at most 72 bytes of input, `x/crypto` returns `ErrPasswordTooLong` above that. `hashPassword` in `gopodder/auth.go` did `hash, _ := bcrypt.GenerateFromPassword(...)` -> on a long password the account was created with an empty pwhash and nobody could log in. Hit every path that sets a password: first-run setup, self-registration, admin create/reset, gpodder user create/reset, API v1.

Not an auth bypass at least, an empty hash never verifies.

The web side now goes through one `hashNewPassword` helper that returns either a usable hash or a message for the user, never both empty -> the validate-then-hash pair cant drift apart again. The two API sites keep their own error handling because a hash failure there is a 500, not a 400.

Scoped out on purpose:

- no sha256 pre-hashing to lift the limit. That changes the hash format and needs a migration path for existing accounts, too much for a one line bug. Worth revisiting if people keep running into it.
- no `maxlength="72"` on the password inputs. A truncated paste creates an account whose password silently differs from what the password manager stored, thats worse than an error message.
- the limit is 72 *bytes*, not characters, so umlauts and emoji run out earlier. The message says bytes for that reason.

## Testing

```
$ go test -count=1 ./...
ok  	github.com/cbrgm/gopodder/cmd/gopodder	0.446s
ok  	github.com/cbrgm/gopodder/gopodder	14.998s
?   	github.com/cbrgm/gopodder/gopodder/pggen	[no test files]
?   	github.com/cbrgm/gopodder/gopodder/sqlcgen	[no test files]
?   	github.com/cbrgm/gopodder/gopodder/web	[no test files]

$ make lint
golangci-lint run --output.text.colors=false --output.tab.colors=false  --timeout 5m
0 issues.
```
