### PR TITLE
fix: stamp a real version on non-tag builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.BOT_PAT_TOKEN }}
+          fetch-depth: 0
 
       - name: Setup golang
         id: golang

--- a/.github/workflows/go-binaries.yml
+++ b/.github/workflows/go-binaries.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Checkout source
         id: source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Setup golang
         id: golang

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ TAGS ?=
 
 ifndef OUTPUT
 	ifeq ($(GITHUB_REF_TYPE), tag)
-		OUTPUT ?= $(subst v,,$(GITHUB_REF_NAME))
+		OUTPUT ?= $(patsubst v%,%,$(GITHUB_REF_NAME))
 	else
 		OUTPUT ?= testing
 	endif
@@ -29,9 +29,9 @@ endif
 
 ifndef VERSION
 	ifeq ($(GITHUB_REF_TYPE), tag)
-		VERSION ?= $(subst v,,$(GITHUB_REF_NAME))
+		VERSION ?= $(patsubst v%,%,$(GITHUB_REF_NAME))
 	else
-		VERSION ?= $(shell git describe --tags --dirty 2>/dev/null || echo dev)
+		VERSION ?= $(patsubst v%,%,$(shell git describe --tags --dirty 2>/dev/null || echo dev))
 	endif
 endif
 

--- a/cmd/gopodder/main.go
+++ b/cmd/gopodder/main.go
@@ -1,20 +1,30 @@
 package main
 
 import (
+	"cmp"
 	"fmt"
 	"log/slog"
 	"os"
 	"runtime"
+	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/cbrgm/gopodder/gopodder"
 )
 
+const (
+	devVersion   = "dev"
+	unknownValue = "unknown"
+)
+
+// Injected at link time by the Makefile. Builds made without it recover the
+// same information from the VCS stamps of the Go toolchain, see resolveBuildInfo.
 var (
-	Version   = "dev"
-	Revision  = "unknown"
-	BuildDate = "unknown"
+	Version   = devVersion
+	Revision  = unknownValue
+	BuildDate = unknownValue
 )
 
 type CLI struct {
@@ -34,11 +44,14 @@ type ServeCmd struct {
 }
 
 func main() {
+	info, _ := debug.ReadBuildInfo()
+	version, revision, buildDate := resolveBuildInfo(Version, Revision, BuildDate, info)
+
 	var cli CLI
 	ctx := kong.Parse(&cli,
 		kong.Name("gopodder"),
 		kong.Description("A gPodder-compatible podcast synchronization server."),
-		kong.Vars{"version": fmt.Sprintf("%s (revision: %s, built: %s)", Version, Revision, BuildDate)},
+		kong.Vars{"version": fmt.Sprintf("%s (revision: %s, built: %s)", version, revision, buildDate)},
 	)
 
 	logger := setupLogger(cli.LogLevel)
@@ -53,9 +66,9 @@ func main() {
 			DBPostgres:         cli.Serve.DBPostgres,
 			DBPostgresPassword: cli.Serve.DBPostgresPassword,
 			Build: gopodder.BuildInfo{
-				Version:   Version,
-				Revision:  Revision,
-				BuildDate: BuildDate,
+				Version:   version,
+				Revision:  revision,
+				BuildDate: buildDate,
 				GoVersion: runtime.Version(),
 				Platform:  runtime.GOOS + "/" + runtime.GOARCH,
 			},
@@ -66,6 +79,55 @@ func main() {
 	default:
 		ctx.FatalIfErrorf(fmt.Errorf("unknown command: %s", ctx.Command()))
 	}
+}
+
+// resolveBuildInfo fills in build metadata the linker did not provide. Values
+// injected via -X always win; the rest is recovered from the VCS stamps the Go
+// toolchain embeds, so a plain "go build" or "go install" still reports the
+// commit it was built from instead of a bare "dev".
+func resolveBuildInfo(version, revision, buildDate string, info *debug.BuildInfo) (string, string, string) {
+	var vcsRevision, vcsTime string
+	var vcsModified bool
+	var moduleVersion string
+
+	if info != nil {
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				vcsRevision = setting.Value
+			case "vcs.time":
+				vcsTime = setting.Value
+			case "vcs.modified":
+				vcsModified = setting.Value == "true"
+			}
+		}
+		if info.Main.Version != "(devel)" {
+			moduleVersion = strings.TrimPrefix(info.Main.Version, "v")
+		}
+	}
+
+	shortRevision := vcsRevision
+	if len(shortRevision) > 7 {
+		shortRevision = shortRevision[:7]
+	}
+	if shortRevision != "" && vcsModified {
+		shortRevision += "-dirty"
+	}
+
+	if version == "" || version == devVersion {
+		version = cmp.Or(moduleVersion, shortRevision, version, devVersion)
+	}
+	if revision == "" || revision == unknownValue {
+		revision = cmp.Or(shortRevision, revision, unknownValue)
+	}
+	if buildDate == "" || buildDate == unknownValue {
+		buildDate = unknownValue
+		if stamped, err := time.Parse(time.RFC3339, vcsTime); err == nil {
+			buildDate = stamped.UTC().Format("20060102")
+		}
+	}
+
+	return version, revision, buildDate
 }
 
 func setupLogger(level string) *slog.Logger {

--- a/cmd/gopodder/main_test.go
+++ b/cmd/gopodder/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log/slog"
+	"runtime/debug"
 	"testing"
 )
 
@@ -39,6 +40,76 @@ func TestSetupLogger(t *testing.T) {
 			logger := setupLogger(level)
 			if logger == nil {
 				t.Error("setupLogger returned nil")
+			}
+		})
+	}
+}
+
+func TestResolveBuildInfo(t *testing.T) {
+	stamped := &debug.BuildInfo{
+		Main: debug.Module{Version: "v1.2.4-0.20260822150227-02a5696e957f"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "02a5696e957f5d3180df93102e4c07f151b1f417"},
+			{Key: "vcs.time", Value: "2026-08-22T15:02:27Z"},
+			{Key: "vcs.modified", Value: "false"},
+		},
+	}
+
+	tests := []struct {
+		name                                string
+		version, revision, buildDate        string
+		info                                *debug.BuildInfo
+		wantVersion, wantRevision, wantDate string
+	}{
+		{
+			name:    "linker values win",
+			version: "1.2.3", revision: "cdd3370", buildDate: "20260821",
+			info:        stamped,
+			wantVersion: "1.2.3", wantRevision: "cdd3370", wantDate: "20260821",
+		},
+		{
+			name:    "unstamped binary falls back to module version",
+			version: devVersion, revision: unknownValue, buildDate: unknownValue,
+			info:        stamped,
+			wantVersion: "1.2.4-0.20260822150227-02a5696e957f", wantRevision: "02a5696", wantDate: "20260822",
+		},
+		{
+			name:    "untagged module falls back to revision",
+			version: devVersion, revision: unknownValue, buildDate: unknownValue,
+			info: &debug.BuildInfo{
+				Main: debug.Module{Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "02a5696e957f5d3180df93102e4c07f151b1f417"},
+					{Key: "vcs.modified", Value: "true"},
+				},
+			},
+			wantVersion: "02a5696-dirty", wantRevision: "02a5696-dirty", wantDate: unknownValue,
+		},
+		{
+			name:    "no build info keeps defaults",
+			version: devVersion, revision: unknownValue, buildDate: unknownValue,
+			info:        nil,
+			wantVersion: devVersion, wantRevision: unknownValue, wantDate: unknownValue,
+		},
+		{
+			name:    "empty values never leak out",
+			version: "", revision: "", buildDate: "",
+			info:        &debug.BuildInfo{},
+			wantVersion: devVersion, wantRevision: unknownValue, wantDate: unknownValue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version, revision, buildDate := resolveBuildInfo(tt.version, tt.revision, tt.buildDate, tt.info)
+			if version != tt.wantVersion {
+				t.Errorf("version = %q, want %q", version, tt.wantVersion)
+			}
+			if revision != tt.wantRevision {
+				t.Errorf("revision = %q, want %q", revision, tt.wantRevision)
+			}
+			if buildDate != tt.wantDate {
+				t.Errorf("buildDate = %q, want %q", buildDate, tt.wantDate)
 			}
 		})
 	}


### PR DESCRIPTION
## What

- `container.yml` + `go-binaries.yml` checkout with `fetch-depth: 0`
- Makefile strips only the leading `v` (`patsubst v%,%` instead of `subst v,,`) and normalizes the `git describe` output the same way
- `cmd/gopodder` falls back to the VCS build info when the linker did not stamp anything

## Why

The status page reads `Build.Version`, which comes from `-X main.Version=` in the Makefile. On a tag build that value is `GITHUB_REF_NAME`, so releases are fine. On every other build the Makefile falls back to `git describe --tags --dirty`, and thats where it breaks: `actions/checkout` defaults to a depth of 1 with no tags fetched, `git describe` fails, and the `|| echo dev` branch kicks in -> the `latest` image ships with `dev` baked into the binary.

Reproduced against the published images:

```
$ docker run --rm ghcr.io/cbrgm/gopodder:latest --version
dev (revision: 4327789, built: 20260814)

$ docker run --rm ghcr.io/cbrgm/gopodder:v1.2.3 --version
1.2.3 (revision: cdd3370, built: 20260821)
```

So the root cause is the shallow checkout, not the version wiring. `fetch-depth: 0` fixes it.

The Go side is the second layer. Since 1.24 the toolchain stamps the main module version and `vcs.*` into every binary, so there is no reason for a binary to ever say "dev" when it knows the commit it was built from. `resolveBuildInfo` only fills in what the linker left at its default, injected values always win. That also gives people who just do `go install github.com/cbrgm/gopodder/cmd/gopodder@latest` a real version instead of `dev`.

## Testing

```
1) normal make build:
1.2.3-6-gc45c37f (revision: c45c37f, built: 20260822)
2) tag build (GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v1.2.3):
1.2.3 (revision: c45c37f, built: 20260822)
3) shallow clone / no tags (VERSION=dev):
1.2.4-0.20260822150847-c45c37f6ad08 (revision: c45c37f, built: 20260822)
4) plain go build, no ldflags:
1.2.4-0.20260822150847-c45c37f6ad08 (revision: c45c37f, built: 20260822)
```

```
$ go test ./cmd/gopodder/ -run TestResolveBuildInfo -v
=== RUN   TestResolveBuildInfo
=== RUN   TestResolveBuildInfo/linker_values_win
=== RUN   TestResolveBuildInfo/unstamped_binary_falls_back_to_module_version
=== RUN   TestResolveBuildInfo/untagged_module_falls_back_to_revision
=== RUN   TestResolveBuildInfo/no_build_info_keeps_defaults
=== RUN   TestResolveBuildInfo/empty_values_never_leak_out
--- PASS: TestResolveBuildInfo (0.00s)
PASS
ok      github.com/cbrgm/gopodder/cmd/gopodder
```

Closes #51
