### PR TITLE
chore: apply Go 1.27 fixes and modernizations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/a-h/templ v0.3.1020
 	github.com/alecthomas/kong v1.16.1
 	github.com/dustin/go-humanize v1.0.1
-	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/prometheus/client_golang v1.24.1
 	golang.org/x/crypto v0.55.0
@@ -31,6 +30,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/google/cel-go v0.28.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cbrgm/gopodder
 
-go 1.26.5
+go 1.27.0
 
 require (
 	github.com/a-h/templ v0.3.1020

--- a/gopodder/api_keys.go
+++ b/gopodder/api_keys.go
@@ -12,8 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/gopodder/auth.go
+++ b/gopodder/auth.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/gopodder/csrf.go
+++ b/gopodder/csrf.go
@@ -1,6 +1,7 @@
 package gopodder
 
 import (
+	"cmp"
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
@@ -40,10 +41,7 @@ func csrfProtect(next http.Handler) http.Handler {
 				return
 			}
 
-			token := r.FormValue("csrf_token")
-			if token == "" {
-				token = r.Header.Get("X-CSRF-Token")
-			}
+			token := cmp.Or(r.FormValue("csrf_token"), r.Header.Get("X-CSRF-Token"))
 			if !validCSRFToken(token, cookie.Value) {
 				http.Error(w, "invalid csrf token", http.StatusForbidden)
 				return

--- a/gopodder/store_postgres.go
+++ b/gopodder/store_postgres.go
@@ -592,10 +592,7 @@ func (s *PostgresStore) GetEpisodes(ctx context.Context, params EpisodeQuery) ([
 
 func (s *PostgresStore) UpdateEpisodes(ctx context.Context, username string, episodes []Episode, timestamp int64) error {
 	for i := 0; i < len(episodes); i += episodeBatchSize {
-		end := i + episodeBatchSize
-		if end > len(episodes) {
-			end = len(episodes)
-		}
+		end := min(i+episodeBatchSize, len(episodes))
 		if err := s.upsertEpisodeBatch(ctx, username, episodes[i:end], timestamp); err != nil {
 			return err
 		}

--- a/gopodder/store_sqlite.go
+++ b/gopodder/store_sqlite.go
@@ -585,10 +585,7 @@ func (s *SQLiteStore) GetEpisodes(ctx context.Context, params EpisodeQuery) ([]E
 
 func (s *SQLiteStore) UpdateEpisodes(ctx context.Context, username string, episodes []Episode, timestamp int64) error {
 	for i := 0; i < len(episodes); i += episodeBatchSize {
-		end := i + episodeBatchSize
-		if end > len(episodes) {
-			end = len(episodes)
-		}
+		end := min(i+episodeBatchSize, len(episodes))
 		if err := s.upsertEpisodeBatch(ctx, username, episodes[i:end], timestamp); err != nil {
 			return err
 		}

--- a/gopodder/web_handler.go
+++ b/gopodder/web_handler.go
@@ -11,10 +11,10 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/cbrgm/gopodder/gopodder/web"
 	"github.com/dustin/go-humanize"
-	"github.com/google/uuid"
 )
 
 const (


### PR DESCRIPTION
## What

Go 1.27 cleanup pass over the codebase, four small things:

- `go.mod` go directive 1.26.5 -> 1.27.0
- `github.com/google/uuid` -> the new stdlib `uuid` package
- hand written batch clamp -> `min` builtin (both stores)
- CSRF token fallback -> `cmp.Or`

## Why

`.go-version` already pins 1.27.0 since #53, so CI was building with 1.27 while the go directive still said 1.26.5. That directive is what gates language features and the `go vet` / `go fix` analyzers, so we were on the new toolchain without actually opting into it. Bumping it first, the rest follows from what `go fix` and the 1.27 stdlib then surface.

The uuid one is the actual 1.27 win. std ships a `uuid` package now, and all 9 call sites were plain `uuid.New().String()` -> straight drop in, no call site changes. Heads up though, it does not disappear from the module graph: `modernc.org/sqlite` pulls it in via `modernc.org/libc`, so it moves to `// indirect` rather than out. What we get is one less direct dependency and one less import to think about, not a smaller build.

`min` and `cmp.Or` are older features (1.21 / 1.22) that `go vet` never flagged, the revamped `go fix` in 1.27 found the `min` ones. Both are cheap and side effect free in the `cmp.Or` case, so evaluating both arms is fine there.

Scoped out on purpose:

- **`encoding/json/v2`**. Tempting, but it changes wire behavior -> nil slices/maps encode as `[]`/`{}` instead of `null`, duplicate object keys get rejected. That would change API responses for clients, so it needs its own PR with proper testing, not a drive by import swap.
- **`omitzero`**. All 8 JSON `omitempty` tags sit on `*string` / `*int64` pointers where `omitempty` is already the right call. The two in `web_handler.go` are XML tags.

Everything else came up empty: no `strings.LastIndex` -> `CutLast`, no URL copying -> `Clone`, no generic helpers, no embedded struct literals, no `sync.WaitGroup`, no `errors.As`, no `sort.Slice`, no `interface{}`. Tests already use `t.Context()` in 72 places and the mux already does method aware patterns with `r.PathValue`, so nothing to do there.

## Testing

No behavior change, this is a pure refactor. `min` and `cmp.Or` are exact rewrites of the branches they replace, and the stdlib uuid API produces the same RFC 9562 v4 output for `New().String()`.

Each of the four commits builds and vets clean on its own, so any of them can be reverted alone.

```
$ go build ./... && go vet ./...
(no output, clean)

$ go test ./...
ok  	github.com/cbrgm/gopodder/cmd/gopodder	0.460s
ok  	github.com/cbrgm/gopodder/gopodder	15.895s
?   	github.com/cbrgm/gopodder/gopodder/pggen	[no test files]
?   	github.com/cbrgm/gopodder/gopodder/sqlcgen	[no test files]
?   	github.com/cbrgm/gopodder/gopodder/web	[no test files]

$ go fix -diff ./...
(empty, nothing left to fix)

$ make lint
golangci-lint run --output.text.colors=false --output.tab.colors=false  --timeout 5m
0 issues.
```

