### PR TITLE
refactor: stdlib helpers and dedup across handlers

### DIFF
--- a/cmd/gopodder/main.go
+++ b/cmd/gopodder/main.go
@@ -138,17 +138,10 @@ func setupLogger(level string) *slog.Logger {
 	return slog.New(handler)
 }
 
+// stringToLogLevel parses a level name, falling back to info for anything
+// slog does not recognize (the zero Level is info).
 func stringToLogLevel(level string) slog.Level {
-	switch strings.ToLower(level) {
-	case "debug":
-		return slog.LevelDebug
-	case "info":
-		return slog.LevelInfo
-	case "warn":
-		return slog.LevelWarn
-	case "error":
-		return slog.LevelError
-	default:
-		return slog.LevelInfo
-	}
+	var l slog.Level
+	_ = l.UnmarshalText([]byte(level))
+	return l
 }

--- a/gopodder/api.go
+++ b/gopodder/api.go
@@ -3,15 +3,12 @@ package gopodder
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 )
-
-const apiPrefix = "/api/2"
 
 type BuildInfo struct {
 	Version   string
@@ -53,16 +50,16 @@ func (a *API) Handler() http.Handler {
 	mux.HandleFunc("GET /clientconfig.json", a.handleClientConfig)
 
 	// gPodder API v2 routes
-	mux.HandleFunc(fmt.Sprintf("POST %s/auth/{username...}", apiPrefix), a.routeAuth)
-	mux.HandleFunc(fmt.Sprintf("GET %s/devices/{username...}", apiPrefix), a.withAuth(a.handleListDevices))
-	mux.HandleFunc(fmt.Sprintf("POST %s/devices/{rest...}", apiPrefix), a.withAuth(a.handleUpdateDevice))
-	mux.HandleFunc(fmt.Sprintf("GET %s/subscriptions/{rest...}", apiPrefix), a.withAuth(a.handleGetSubscriptionChanges))
-	mux.HandleFunc(fmt.Sprintf("POST %s/subscriptions/{rest...}", apiPrefix), a.withAuth(a.handleUploadSubscriptionChanges))
+	mux.HandleFunc("POST /api/2/auth/{username...}", a.routeAuth)
+	mux.HandleFunc("GET /api/2/devices/{username...}", a.withAuth(a.handleListDevices))
+	mux.HandleFunc("POST /api/2/devices/{rest...}", a.withAuth(a.handleUpdateDevice))
+	mux.HandleFunc("GET /api/2/subscriptions/{rest...}", a.withAuth(a.handleGetSubscriptionChanges))
+	mux.HandleFunc("POST /api/2/subscriptions/{rest...}", a.withAuth(a.handleUploadSubscriptionChanges))
 	mux.HandleFunc("GET /subscriptions/{rest...}", a.withAuth(a.routeGetSubscriptions))
 	mux.HandleFunc("PUT /subscriptions/{rest...}", a.withAuth(a.handleUploadSubscriptions))
-	mux.HandleFunc(fmt.Sprintf("PUT %s/subscriptions/{rest...}", apiPrefix), a.withAuth(a.handleUploadSubscriptions))
-	mux.HandleFunc(fmt.Sprintf("GET %s/episodes/{username...}", apiPrefix), a.withAuth(a.handleGetEpisodes))
-	mux.HandleFunc(fmt.Sprintf("POST %s/episodes/{username...}", apiPrefix), a.withAuth(a.handleUploadEpisodes))
+	mux.HandleFunc("PUT /api/2/subscriptions/{rest...}", a.withAuth(a.handleUploadSubscriptions))
+	mux.HandleFunc("GET /api/2/episodes/{username...}", a.withAuth(a.handleGetEpisodes))
+	mux.HandleFunc("POST /api/2/episodes/{username...}", a.withAuth(a.handleUploadEpisodes))
 
 	// Stub endpoints for directory/discovery features (gPodder desktop compatibility)
 	mux.HandleFunc("GET /toplist/opml", a.handleEmptyOPML)
@@ -93,11 +90,7 @@ func (a *API) handleHealthz(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleClientConfig(w http.ResponseWriter, r *http.Request) {
-	scheme := "http"
-	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-		scheme = "https"
-	}
-	base := scheme + "://" + r.Host
+	base := requestBaseURL(r)
 
 	resp := map[string]string{
 		"mygpo":             base + "/api/2",
@@ -182,10 +175,27 @@ func parseDevicePath(r *http.Request) (deviceID string, ok bool) {
 	return stripExtension(parts[1]), true
 }
 
+// isHTTPS reports whether the request reached us over TLS, directly or via a
+// terminating proxy.
+func isHTTPS(r *http.Request) bool {
+	return r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
+}
+
+func requestBaseURL(r *http.Request) string {
+	if isHTTPS(r) {
+		return "https://" + r.Host
+	}
+	return "http://" + r.Host
+}
+
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
 }
 
 func parseQueryInt64(r *http.Request, key string, def int64) int64 {

--- a/gopodder/api_keys.go
+++ b/gopodder/api_keys.go
@@ -1,7 +1,6 @@
 package gopodder
 
 import (
-	"cmp"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -9,7 +8,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 	"uuid"
@@ -78,11 +76,11 @@ func (a *API) withAPIKey(requiredRole string, next http.HandlerFunc) http.Handle
 	return func(w http.ResponseWriter, r *http.Request) {
 		acct, key, ok := a.authenticateAPIKey(r)
 		if !ok {
-			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+			writeJSONError(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 		if requiredRole == RoleAdmin && key.Role != RoleAdmin {
-			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+			writeJSONError(w, http.StatusForbidden, "forbidden")
 			return
 		}
 		ctx := context.WithValue(r.Context(), contextKeyAPIAccount, acct)
@@ -98,29 +96,29 @@ func (a *API) requireOwnedUser(w http.ResponseWriter, r *http.Request) (string, 
 
 	user, err := a.store.GetUser(r.Context(), username)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "user not found"})
+		writeJSONError(w, http.StatusNotFound, "user not found")
 		return "", false
 	}
 	if user.AccountID != acct.ID {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "user does not belong to your account"})
+		writeJSONError(w, http.StatusForbidden, "user does not belong to your account")
 		return "", false
 	}
 	return username, true
 }
 
 func (a *API) registerAPIv1Routes(mux *http.ServeMux) {
-	mux.HandleFunc(fmt.Sprintf("GET %s/users", apiV1Prefix), a.withAPIKey(RoleStandard, a.handleAPIListUsers))
-	mux.HandleFunc(fmt.Sprintf("POST %s/users", apiV1Prefix), a.withAPIKey(RoleStandard, a.handleAPICreateUser))
-	mux.HandleFunc(fmt.Sprintf("DELETE %s/users/{username}", apiV1Prefix), a.withAPIKey(RoleStandard, a.handleAPIDeleteUser))
-	mux.HandleFunc(fmt.Sprintf("GET %s/users/{username}/devices", apiV1Prefix), a.withAPIKey(RoleStandard, a.handleAPIListDevices))
-	mux.HandleFunc(fmt.Sprintf("GET %s/users/{username}/subscriptions", apiV1Prefix), a.withAPIKey(RoleStandard, a.handleAPIGetSubscriptions))
-	mux.HandleFunc(fmt.Sprintf("GET %s/users/{username}/subscriptions.opml", apiV1Prefix), a.withAPIKey(RoleStandard, a.handleAPIGetSubscriptionsOPML))
-	mux.HandleFunc(fmt.Sprintf("POST %s/users/{username}/subscriptions", apiV1Prefix), a.withAPIKey(RoleStandard, a.handleAPIUpdateSubscriptions))
+	mux.HandleFunc("GET /api/v1/users", a.withAPIKey(RoleStandard, a.handleAPIListUsers))
+	mux.HandleFunc("POST /api/v1/users", a.withAPIKey(RoleStandard, a.handleAPICreateUser))
+	mux.HandleFunc("DELETE /api/v1/users/{username}", a.withAPIKey(RoleStandard, a.handleAPIDeleteUser))
+	mux.HandleFunc("GET /api/v1/users/{username}/devices", a.withAPIKey(RoleStandard, a.handleAPIListDevices))
+	mux.HandleFunc("GET /api/v1/users/{username}/subscriptions", a.withAPIKey(RoleStandard, a.handleAPIGetSubscriptions))
+	mux.HandleFunc("GET /api/v1/users/{username}/subscriptions.opml", a.withAPIKey(RoleStandard, a.handleAPIGetSubscriptionsOPML))
+	mux.HandleFunc("POST /api/v1/users/{username}/subscriptions", a.withAPIKey(RoleStandard, a.handleAPIUpdateSubscriptions))
 
-	mux.HandleFunc(fmt.Sprintf("GET %s/accounts", apiV1Prefix), a.withAPIKey(RoleAdmin, a.handleAPIListAccounts))
-	mux.HandleFunc(fmt.Sprintf("POST %s/accounts", apiV1Prefix), a.withAPIKey(RoleAdmin, a.handleAPICreateAccount))
-	mux.HandleFunc(fmt.Sprintf("DELETE %s/accounts/{id}", apiV1Prefix), a.withAPIKey(RoleAdmin, a.handleAPIDeleteAccount))
-	mux.HandleFunc(fmt.Sprintf("GET %s/accounts/{id}/users", apiV1Prefix), a.withAPIKey(RoleAdmin, a.handleAPIListAccountUsers))
+	mux.HandleFunc("GET /api/v1/accounts", a.withAPIKey(RoleAdmin, a.handleAPIListAccounts))
+	mux.HandleFunc("POST /api/v1/accounts", a.withAPIKey(RoleAdmin, a.handleAPICreateAccount))
+	mux.HandleFunc("DELETE /api/v1/accounts/{id}", a.withAPIKey(RoleAdmin, a.handleAPIDeleteAccount))
+	mux.HandleFunc("GET /api/v1/accounts/{id}/users", a.withAPIKey(RoleAdmin, a.handleAPIListAccountUsers))
 }
 
 // Standard key handlers
@@ -147,7 +145,7 @@ func (a *API) handleAPIListUsers(w http.ResponseWriter, r *http.Request) {
 	users, err := a.store.ListUsersByAccount(r.Context(), acct.ID)
 	if err != nil {
 		a.logger.Error("failed to list users", "err", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
 	writeJSON(w, http.StatusOK, usersToResponse(users))
@@ -161,42 +159,42 @@ func (a *API) handleAPICreateUser(w http.ResponseWriter, r *http.Request) {
 		Password string `json:"password"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		writeJSONError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 	if req.Username == "" || req.Password == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "username and password are required"})
+		writeJSONError(w, http.StatusBadRequest, "username and password are required")
 		return
 	}
 	if !isValidUsername(req.Username) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid username"})
+		writeJSONError(w, http.StatusBadRequest, "invalid username")
 		return
 	}
 	if msg := a.checkPasswordLength(r.Context(), req.Password); msg != "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": msg})
+		writeJSONError(w, http.StatusBadRequest, msg)
 		return
 	}
 	if !a.userCreationAllowed(r.Context(), acct) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "user creation is disabled"})
+		writeJSONError(w, http.StatusForbidden, "user creation is disabled")
 		return
 	}
-	if a.userLimitReached(r.Context(), acct.ID) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "user limit reached for this account"})
+	if userLimitReached(r.Context(), a.store, acct.ID) {
+		writeJSONError(w, http.StatusForbidden, "user limit reached for this account")
 		return
 	}
 	if _, err := a.store.GetUser(r.Context(), req.Username); err == nil {
-		writeJSON(w, http.StatusConflict, map[string]string{"error": "username already exists"})
+		writeJSONError(w, http.StatusConflict, "username already exists")
 		return
 	}
 	pwhash, err := hashPassword(req.Password)
 	if err != nil {
 		a.logger.Error("failed to hash password", "err", err, "username", req.Username)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create user"})
+		writeJSONError(w, http.StatusInternalServerError, "failed to create user")
 		return
 	}
 	if err := a.store.CreateUser(r.Context(), req.Username, pwhash, acct.ID); err != nil {
 		a.logger.Error("failed to create user", "err", err, "username", req.Username)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create user"})
+		writeJSONError(w, http.StatusInternalServerError, "failed to create user")
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]string{"username": req.Username})
@@ -214,9 +212,7 @@ func (a *API) userCreationAllowed(ctx context.Context, acct *Account) bool {
 }
 
 func (a *API) checkPasswordLength(ctx context.Context, password string) string {
-	val, _ := a.store.GetSetting(ctx, SettingMinPasswordLength)
-	minLen, _ := strconv.ParseInt(val, 10, 64)
-	minLen = cmp.Or(minLen, 8)
+	minLen := minPasswordLength(ctx, a.store)
 	if int64(len(password)) < minLen {
 		return fmt.Sprintf("password must be at least %d characters", minLen)
 	}
@@ -224,19 +220,6 @@ func (a *API) checkPasswordLength(ctx context.Context, password string) string {
 		return fmt.Sprintf("password must be at most %d bytes long", maxPasswordBytes)
 	}
 	return ""
-}
-
-func (a *API) userLimitReached(ctx context.Context, accountID string) bool {
-	val, _ := a.store.GetSetting(ctx, SettingMaxUsersPerAccount)
-	limit, _ := strconv.ParseInt(val, 10, 64)
-	if limit <= 0 {
-		return false
-	}
-	users, err := a.store.ListUsersByAccount(ctx, accountID)
-	if err != nil {
-		return false
-	}
-	return int64(len(users)) >= limit
 }
 
 func (a *API) handleAPIDeleteUser(w http.ResponseWriter, r *http.Request) {
@@ -264,7 +247,7 @@ func (a *API) handleAPIListDevices(w http.ResponseWriter, r *http.Request) {
 	devices, err := a.store.ListDevices(r.Context(), username)
 	if err != nil {
 		a.logger.Error("failed to list devices", "err", err, "username", username)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
 	subs, _ := a.store.GetSubscriptions(r.Context(), username)
@@ -294,7 +277,7 @@ func (a *API) handleAPIGetSubscriptions(w http.ResponseWriter, r *http.Request) 
 	subs, err := a.store.GetSubscriptions(r.Context(), username)
 	if err != nil {
 		a.logger.Error("failed to get subscriptions", "err", err, "username", username)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
 	if subs == nil {
@@ -311,7 +294,7 @@ func (a *API) handleAPIGetSubscriptionsOPML(w http.ResponseWriter, r *http.Reque
 	subs, err := a.store.GetSubscriptions(r.Context(), username)
 	if err != nil {
 		a.logger.Error("failed to get subscriptions", "err", err, "username", username)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
 
@@ -343,7 +326,7 @@ func (a *API) handleAPIUpdateSubscriptions(w http.ResponseWriter, r *http.Reques
 		Remove []string `json:"remove"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		writeJSONError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 
@@ -351,7 +334,7 @@ func (a *API) handleAPIUpdateSubscriptions(w http.ResponseWriter, r *http.Reques
 	req.Remove = filterValidURLs(req.Remove)
 
 	if hasOverlap(req.Add, req.Remove) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "same URL in add and remove"})
+		writeJSONError(w, http.StatusBadRequest, "same URL in add and remove")
 		return
 	}
 
@@ -361,7 +344,7 @@ func (a *API) handleAPIUpdateSubscriptions(w http.ResponseWriter, r *http.Reques
 	}
 	if err := a.store.UpdateSubscriptions(r.Context(), username, req.Add, req.Remove, now); err != nil {
 		a.logger.Error("failed to update subscriptions", "err", err, "username", username)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update subscriptions"})
+		writeJSONError(w, http.StatusInternalServerError, "failed to update subscriptions")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"timestamp": now})
@@ -373,7 +356,7 @@ func (a *API) handleAPIListAccounts(w http.ResponseWriter, r *http.Request) {
 	accounts, err := a.store.ListAccounts(r.Context())
 	if err != nil {
 		a.logger.Error("failed to list accounts", "err", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
 	type acctResp struct {
@@ -410,19 +393,19 @@ func (a *API) handleAPICreateAccount(w http.ResponseWriter, r *http.Request) {
 		Role     string `json:"role"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		writeJSONError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 	if req.Username == "" || req.Password == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "username and password are required"})
+		writeJSONError(w, http.StatusBadRequest, "username and password are required")
 		return
 	}
 	if !isValidUsername(req.Username) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid username"})
+		writeJSONError(w, http.StatusBadRequest, "invalid username")
 		return
 	}
 	if msg := a.checkPasswordLength(r.Context(), req.Password); msg != "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": msg})
+		writeJSONError(w, http.StatusBadRequest, msg)
 		return
 	}
 	if req.Role != RoleAdmin {
@@ -430,19 +413,19 @@ func (a *API) handleAPICreateAccount(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := a.store.GetAccount(r.Context(), req.Username); err == nil {
-		writeJSON(w, http.StatusConflict, map[string]string{"error": "account already exists"})
+		writeJSONError(w, http.StatusConflict, "account already exists")
 		return
 	}
 	pwhash, err := hashPassword(req.Password)
 	if err != nil {
 		a.logger.Error("failed to hash password", "err", err, "username", req.Username)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create account"})
+		writeJSONError(w, http.StatusInternalServerError, "failed to create account")
 		return
 	}
 	id := uuid.New().String()
 	if err := a.store.CreateAccount(r.Context(), id, req.Username, pwhash, req.Role, time.Now()); err != nil {
 		a.logger.Error("failed to create account", "err", err, "username", req.Username)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create account"})
+		writeJSONError(w, http.StatusInternalServerError, "failed to create account")
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]string{"id": id, "username": req.Username, "role": req.Role})
@@ -452,11 +435,11 @@ func (a *API) handleAPIDeleteAccount(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	acct, err := a.store.GetAccountByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "account not found"})
+		writeJSONError(w, http.StatusNotFound, "account not found")
 		return
 	}
 	if acct.Role == RoleAdmin {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "cannot delete admin accounts via API"})
+		writeJSONError(w, http.StatusBadRequest, "cannot delete admin accounts via API")
 		return
 	}
 	deleteAccountCascade(r.Context(), a.store, id)
@@ -466,13 +449,13 @@ func (a *API) handleAPIDeleteAccount(w http.ResponseWriter, r *http.Request) {
 func (a *API) handleAPIListAccountUsers(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if _, err := a.store.GetAccountByID(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "account not found"})
+		writeJSONError(w, http.StatusNotFound, "account not found")
 		return
 	}
 	users, err := a.store.ListUsersByAccount(r.Context(), id)
 	if err != nil {
 		a.logger.Error("failed to list account users", "err", err, "account_id", id)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+		writeJSONError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
 	writeJSON(w, http.StatusOK, usersToResponse(users))

--- a/gopodder/api_keys.go
+++ b/gopodder/api_keys.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"encoding/xml"
 	"fmt"
 	"net/http"
 	"strings"
@@ -298,21 +297,7 @@ func (a *API) handleAPIGetSubscriptionsOPML(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	outlines := make([]opmlOutline, 0, len(subs))
-	for _, u := range subs {
-		outlines = append(outlines, opmlOutline{Type: "rss", Text: u, Title: u, XMLURL: u})
-	}
-	doc := opmlDoc{
-		Version: "2.0",
-		Head:    opmlHead{Title: fmt.Sprintf("goPodder subscriptions for %s", username)},
-		Body:    opmlBody{Outlines: outlines},
-	}
-
-	w.Header().Set("Content-Type", "text/x-opml+xml")
-	_, _ = w.Write([]byte(xml.Header))
-	enc := xml.NewEncoder(w)
-	enc.Indent("", "  ")
-	_ = enc.Encode(doc)
+	writeOPML(w, fmt.Sprintf("goPodder subscriptions for %s", username), subs)
 }
 
 func (a *API) handleAPIUpdateSubscriptions(w http.ResponseWriter, r *http.Request) {

--- a/gopodder/api_subscriptions.go
+++ b/gopodder/api_subscriptions.go
@@ -3,7 +3,6 @@ package gopodder
 import (
 	"context"
 	"encoding/json"
-	"encoding/xml"
 	"fmt"
 	"net/http"
 	"slices"
@@ -46,7 +45,7 @@ func (a *API) handleGetAllSubscriptions(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if strings.HasSuffix(r.URL.Path, ".opml") {
-		a.writeSubscriptionsOPML(w, username, subs)
+		writeOPML(w, fmt.Sprintf("%s subscriptions", username), subs)
 		return
 	}
 
@@ -195,24 +194,6 @@ func (a *API) handleUploadSubscriptionChanges(w http.ResponseWriter, r *http.Req
 		Timestamp:  now + 1,
 		UpdateURLs: [][]string{},
 	})
-}
-
-func (a *API) writeSubscriptionsOPML(w http.ResponseWriter, username string, subs []string) {
-	outlines := make([]opmlOutline, 0, len(subs))
-	for _, u := range subs {
-		outlines = append(outlines, opmlOutline{Type: "rss", Text: u, Title: u, XMLURL: u})
-	}
-	doc := opmlDoc{
-		Version: "2.0",
-		Head:    opmlHead{Title: fmt.Sprintf("%s subscriptions", username)},
-		Body:    opmlBody{Outlines: outlines},
-	}
-
-	w.Header().Set("Content-Type", "text/x-opml+xml")
-	_, _ = w.Write([]byte(xml.Header))
-	enc := xml.NewEncoder(w)
-	enc.Indent("", "  ")
-	_ = enc.Encode(doc)
 }
 
 func (a *API) warnUnmatchedRemovals(ctx context.Context, username, device string, removed []string) {

--- a/gopodder/auth.go
+++ b/gopodder/auth.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"context"
 	"net/http"
-	"strconv"
 	"time"
 	"uuid"
 
@@ -54,9 +53,7 @@ func (a *API) apiSessionExpired(ctx context.Context, sessionCreated *time.Time) 
 	if sessionCreated == nil {
 		return true
 	}
-	val, _ := a.store.GetSetting(ctx, SettingSessionMaxAge)
-	hours, _ := strconv.ParseInt(val, 10, 64)
-	hours = cmp.Or(hours, defaultSessionMaxAgeHours)
+	hours := cmp.Or(settingInt(ctx, a.store, SettingSessionMaxAge), defaultSessionMaxAgeHours)
 	return time.Since(*sessionCreated) > time.Duration(hours)*time.Hour
 }
 
@@ -89,17 +86,14 @@ func (a *API) handleLogin(w http.ResponseWriter, r *http.Request) {
 	sessionID := uuid.New().String()
 	_ = a.store.UpdateUserSession(r.Context(), username, &sessionID, time.Now())
 
-	maxAge, _ := a.store.GetSetting(r.Context(), SettingSessionMaxAge)
-	maxAgeHours, _ := strconv.ParseInt(maxAge, 10, 64)
-	maxAgeHours = cmp.Or(maxAgeHours, defaultSessionMaxAgeHours)
+	maxAgeHours := cmp.Or(settingInt(r.Context(), a.store, SettingSessionMaxAge), defaultSessionMaxAgeHours)
 
-	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 	http.SetCookie(w, &http.Cookie{
 		Name:     "sessionid",
 		Value:    sessionID,
 		Path:     "/",
 		HttpOnly: true,
-		Secure:   secure,
+		Secure:   isHTTPS(r),
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   int(maxAgeHours) * 3600,
 	})

--- a/gopodder/middleware.go
+++ b/gopodder/middleware.go
@@ -2,6 +2,7 @@ package gopodder
 
 import (
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -56,22 +57,20 @@ func (rw *responseWriter) WriteHeader(code int) {
 }
 
 func metricsPath(path string) string {
-	if len(path) >= 7 && path[:7] == "/api/v1" {
-		return "/api/v1"
+	if strings.HasPrefix(path, apiV1Prefix) {
+		return apiV1Prefix
 	}
 	if hasAPIPrefix(path) {
 		return "/api/v2"
 	}
-	if len(path) > 1 && path[0] == '/' {
-		for i := 1; i < len(path); i++ {
-			if path[i] == '/' {
-				return path[:i]
-			}
+	if rest, ok := strings.CutPrefix(path, "/"); ok {
+		if segment, _, found := strings.Cut(rest, "/"); found {
+			return "/" + segment
 		}
 	}
 	return path
 }
 
 func hasAPIPrefix(path string) bool {
-	return len(path) >= 5 && path[:5] == "/api/"
+	return strings.HasPrefix(path, "/api/")
 }

--- a/gopodder/server.go
+++ b/gopodder/server.go
@@ -150,7 +150,7 @@ func cleanupInactiveAccounts(logger *slog.Logger, store Store) {
 	}
 }
 
-func getClampedSetting(store Store, key string, defaultVal, min, max int) int {
+func getClampedSetting(store Store, key string, defaultVal, lo, hi int) int {
 	val, err := store.GetSetting(context.Background(), key)
 	if err != nil {
 		return defaultVal
@@ -159,13 +159,7 @@ func getClampedSetting(store Store, key string, defaultVal, min, max int) int {
 	if n == 0 {
 		return 0
 	}
-	if n < min {
-		return min
-	}
-	if n > max {
-		return max
-	}
-	return n
+	return min(max(n, lo), hi)
 }
 
 func openStore(cfg Config) (Store, error) {

--- a/gopodder/server_test.go
+++ b/gopodder/server_test.go
@@ -213,11 +213,26 @@ func TestRun_StartsAndShutdown(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(100 * time.Millisecond)
-
-	resp, err := http.Get("http://127.0.0.1:19876/api/2/devices/test.json")
-	if err != nil {
-		t.Fatalf("failed to connect to server: %v", err)
+	// Poll for the listener instead of guessing how long startup takes, and
+	// check errCh on the way so a startup failure is reported as itself
+	// rather than as a connection error.
+	var resp *http.Response
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		var err error
+		resp, err = http.Get("http://127.0.0.1:19876/api/2/devices/test.json")
+		if err == nil {
+			break
+		}
+		select {
+		case runErr := <-errCh:
+			t.Fatalf("Run returned before the server came up: %v", runErr)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("server did not come up within 10s: %v", err)
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusUnauthorized {

--- a/gopodder/store_helpers.go
+++ b/gopodder/store_helpers.go
@@ -1,9 +1,12 @@
 package gopodder
 
 import (
+	"cmp"
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -142,4 +145,30 @@ func diffSubscriptions(existing, desired []string) (add, remove []string) {
 		}
 	}
 	return add, remove
+}
+
+// settingInt reads a numeric setting, returning 0 when it is unset or unparsable.
+func settingInt(ctx context.Context, store Store, key string) int64 {
+	val, err := store.GetSetting(ctx, key)
+	if err != nil {
+		return 0
+	}
+	n, _ := strconv.ParseInt(val, 10, 64)
+	return n
+}
+
+func minPasswordLength(ctx context.Context, store Store) int64 {
+	return cmp.Or(settingInt(ctx, store, SettingMinPasswordLength), 8)
+}
+
+func userLimitReached(ctx context.Context, store Store, accountID string) bool {
+	limit := settingInt(ctx, store, SettingMaxUsersPerAccount)
+	if limit <= 0 {
+		return false
+	}
+	users, err := store.ListUsersByAccount(ctx, accountID)
+	if err != nil {
+		return false
+	}
+	return int64(len(users)) >= limit
 }

--- a/gopodder/validate.go
+++ b/gopodder/validate.go
@@ -3,6 +3,7 @@ package gopodder
 import (
 	"net/url"
 	"regexp"
+	"slices"
 )
 
 var validIdentifier = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,64}$`)
@@ -23,11 +24,5 @@ func isValidFeedURL(s string) bool {
 }
 
 func filterValidURLs(urls []string) []string {
-	valid := urls[:0]
-	for _, u := range urls {
-		if isValidFeedURL(u) {
-			valid = append(valid, u)
-		}
-	}
-	return valid
+	return slices.DeleteFunc(urls, func(u string) bool { return !isValidFeedURL(u) })
 }

--- a/gopodder/web_handler.go
+++ b/gopodder/web_handler.go
@@ -226,7 +226,7 @@ func (h *WebHandler) handleLoginSubmit(w http.ResponseWriter, r *http.Request) {
 		Value:    sessionID,
 		Path:     "/",
 		HttpOnly: true,
-		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+		Secure:   isHTTPS(r),
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   int(maxAge) * 3600,
 	})
@@ -389,7 +389,7 @@ func (h *WebHandler) handleCreateAPIKey(w http.ResponseWriter, r *http.Request) 
 		Value:    raw,
 		Path:     "/account",
 		HttpOnly: true,
-		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+		Secure:   isHTTPS(r),
 		SameSite: http.SameSiteStrictMode,
 		MaxAge:   60,
 	})
@@ -694,11 +694,7 @@ func (h *WebHandler) buildUserDetailData(ctx context.Context, r *http.Request, a
 	var shareToken, shareOPMLURL, shareRSSURL string
 	if user != nil && user.ShareToken != nil {
 		shareToken = *user.ShareToken
-		scheme := "http"
-		if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-			scheme = "https"
-		}
-		base := scheme + "://" + r.Host
+		base := requestBaseURL(r)
 		shareOPMLURL = base + "/user/" + username + "/subscriptions.opml?token=" + shareToken
 		shareRSSURL = base + "/user/" + username + "/subscriptions/rss?token=" + shareToken
 	}
@@ -741,7 +737,7 @@ func (h *WebHandler) handleStatusPage(w http.ResponseWriter, r *http.Request) {
 			Episodes:      stats.Episodes,
 		},
 		Uptime:     time.Since(h.startedAt).Truncate(time.Second).String(),
-		MemAlloc:   formatBytes(mem.Alloc),
+		MemAlloc:   humanize.IBytes(mem.Alloc),
 		Goroutines: runtime.NumGoroutine(),
 		Version:    h.build.Version,
 		Revision:   h.build.Revision,
@@ -1137,13 +1133,13 @@ func (h *WebHandler) handleSettingsSave(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	_ = h.store.SetSetting(ctx, SettingSelfRegistration, boolString(r.FormValue("self_registration") == "true"))
-	_ = h.store.SetSetting(ctx, SettingAllowUserCreation, boolString(r.FormValue("allow_user_creation") == "true"))
-	_ = h.store.SetSetting(ctx, SettingAllowSharing, boolString(r.FormValue("allow_sharing") == "true"))
-	_ = h.store.SetSetting(ctx, SettingAllowAPIKeys, boolString(r.FormValue("allow_api_keys") == "true"))
-	_ = h.store.SetSetting(ctx, SettingMaxUsersPerAccount, clampedIntString(r.FormValue("max_users_per_account")))
+	_ = h.store.SetSetting(ctx, SettingSelfRegistration, strconv.FormatBool(r.FormValue("self_registration") == "true"))
+	_ = h.store.SetSetting(ctx, SettingAllowUserCreation, strconv.FormatBool(r.FormValue("allow_user_creation") == "true"))
+	_ = h.store.SetSetting(ctx, SettingAllowSharing, strconv.FormatBool(r.FormValue("allow_sharing") == "true"))
+	_ = h.store.SetSetting(ctx, SettingAllowAPIKeys, strconv.FormatBool(r.FormValue("allow_api_keys") == "true"))
+	_ = h.store.SetSetting(ctx, SettingMaxUsersPerAccount, clampedMinIntString(r.FormValue("max_users_per_account"), 0))
 	_ = h.store.SetSetting(ctx, SettingMaxAPIKeys, clampedMinIntString(r.FormValue("max_api_keys_per_account"), 1))
-	_ = h.store.SetSetting(ctx, SettingMinPasswordLength, clampedIntString(r.FormValue("min_password_length")))
+	_ = h.store.SetSetting(ctx, SettingMinPasswordLength, clampedMinIntString(r.FormValue("min_password_length"), 0))
 	_ = h.store.SetSetting(ctx, SettingSessionMaxAge, strconv.Itoa(sessionMaxAge))
 	_ = h.store.SetSetting(ctx, SettingEpisodeRetention, strconv.Itoa(episodeRetention))
 	_ = h.store.SetSetting(ctx, SettingInactiveAccountDays, strconv.Itoa(inactiveAccountDays))
@@ -1173,16 +1169,11 @@ func (h *WebHandler) isSettingEnabled(ctx context.Context, key string) bool {
 }
 
 func (h *WebHandler) getSettingInt(ctx context.Context, key string) int64 {
-	val, err := h.store.GetSetting(ctx, key)
-	if err != nil {
-		return 0
-	}
-	n, _ := strconv.ParseInt(val, 10, 64)
-	return n
+	return settingInt(ctx, h.store, key)
 }
 
 func (h *WebHandler) checkPasswordLength(ctx context.Context, password string) string {
-	minLen := cmp.Or(h.getSettingInt(ctx, SettingMinPasswordLength), 8)
+	minLen := minPasswordLength(ctx, h.store)
 	if int64(len(password)) < minLen {
 		return fmt.Sprintf("Password must be at least %d characters.", minLen)
 	}
@@ -1208,15 +1199,7 @@ func (h *WebHandler) hashNewPassword(ctx context.Context, password string) (hash
 }
 
 func (h *WebHandler) userLimitReached(ctx context.Context, accountID string) bool {
-	limit := h.getSettingInt(ctx, SettingMaxUsersPerAccount)
-	if limit <= 0 {
-		return false
-	}
-	users, err := h.store.ListUsersByAccount(ctx, accountID)
-	if err != nil {
-		return false
-	}
-	return int64(len(users)) >= limit
+	return userLimitReached(ctx, h.store, accountID)
 }
 
 // OPML
@@ -1540,40 +1523,9 @@ func (h *WebHandler) isLastAdmin(ctx context.Context, id string) bool {
 	return true
 }
 
-func boolString(v bool) string {
-	if v {
-		return "true"
-	}
-	return "false"
-}
-
-func clampedIntString(s string) string {
-	n, _ := strconv.ParseInt(s, 10, 64)
-	if n < 0 {
-		n = 0
-	}
-	return strconv.FormatInt(n, 10)
-}
-
 func clampedMinIntString(s string, minVal int64) string {
 	n, _ := strconv.ParseInt(s, 10, 64)
-	if n < minVal {
-		n = minVal
-	}
-	return strconv.FormatInt(n, 10)
-}
-
-func formatBytes(b uint64) string {
-	const unit = 1024
-	if b < unit {
-		return fmt.Sprintf("%d B", b)
-	}
-	div, exp := uint64(unit), 0
-	for n := b / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+	return strconv.FormatInt(max(n, minVal), 10)
 }
 
 func formatTimestamp(t time.Time) string {

--- a/gopodder/web_handler.go
+++ b/gopodder/web_handler.go
@@ -1228,6 +1228,28 @@ type opmlOutline struct {
 	Outlines []opmlOutline `xml:"outline"`
 }
 
+// writeOPML renders a subscription list as an OPML 2.0 document.
+func writeOPML(w http.ResponseWriter, title string, subs []string) {
+	outlines := make([]opmlOutline, 0, len(subs))
+	for _, u := range subs {
+		outlines = append(outlines, opmlOutline{Type: "rss", Text: u, Title: u, XMLURL: u})
+	}
+	doc := opmlDoc{
+		Version: "2.0",
+		Head: opmlHead{
+			Title:       title,
+			DateCreated: time.Now().UTC().Format(time.RFC1123Z),
+		},
+		Body: opmlBody{Outlines: outlines},
+	}
+
+	w.Header().Set("Content-Type", "text/x-opml+xml")
+	_, _ = w.Write([]byte(xml.Header))
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	_ = enc.Encode(doc)
+}
+
 func (h *WebHandler) handleOPML(w http.ResponseWriter, r *http.Request) {
 	acct := webAccountFromContext(r.Context())
 	username := r.URL.Query().Get("user")
@@ -1248,28 +1270,8 @@ func (h *WebHandler) handleOPML(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	outlines := make([]opmlOutline, 0, len(subs))
-	for _, u := range subs {
-		outlines = append(outlines, opmlOutline{Type: "rss", Text: u, Title: u, XMLURL: u})
-	}
-
-	doc := opmlDoc{
-		Version: "2.0",
-		Head: opmlHead{
-			Title:       fmt.Sprintf("goPodder subscriptions for %s", username),
-			DateCreated: time.Now().UTC().Format(time.RFC1123Z),
-		},
-		Body: opmlBody{Outlines: outlines},
-	}
-
-	filename := fmt.Sprintf("%s-subscriptions.opml", username)
-
-	w.Header().Set("Content-Type", "text/x-opml+xml")
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
-	_, _ = w.Write([]byte(xml.Header))
-	enc := xml.NewEncoder(w)
-	enc.Indent("", "  ")
-	_ = enc.Encode(doc)
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s-subscriptions.opml"`, username))
+	writeOPML(w, fmt.Sprintf("goPodder subscriptions for %s", username), subs)
 }
 
 func (h *WebHandler) parseOPMLUpload(r *http.Request) ([]string, error) {
@@ -1364,25 +1366,7 @@ func (h *WebHandler) handlePublicOPML(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	outlines := make([]opmlOutline, 0, len(subs))
-	for _, u := range subs {
-		outlines = append(outlines, opmlOutline{Type: "rss", Text: u, Title: u, XMLURL: u})
-	}
-
-	doc := opmlDoc{
-		Version: "2.0",
-		Head: opmlHead{
-			Title:       fmt.Sprintf("goPodder subscriptions for %s", username),
-			DateCreated: time.Now().UTC().Format(time.RFC1123Z),
-		},
-		Body: opmlBody{Outlines: outlines},
-	}
-
-	w.Header().Set("Content-Type", "text/x-opml+xml")
-	_, _ = w.Write([]byte(xml.Header))
-	enc := xml.NewEncoder(w)
-	enc.Indent("", "  ")
-	_ = enc.Encode(doc)
+	writeOPML(w, fmt.Sprintf("goPodder subscriptions for %s", username), subs)
 }
 
 func (h *WebHandler) handlePublicRSS(w http.ResponseWriter, r *http.Request) {

--- a/gopodder/web_handler_test.go
+++ b/gopodder/web_handler_test.go
@@ -36,31 +36,6 @@ func createMultipartFileWithCSRF(t *testing.T, fieldName, fileName, content, ses
 	return strings.NewReader(b.String()), w.FormDataContentType()
 }
 
-func TestFormatBytes(t *testing.T) {
-	tests := []struct {
-		input uint64
-		want  string
-	}{
-		{0, "0 B"},
-		{512, "512 B"},
-		{1023, "1023 B"},
-		{1024, "1.0 KiB"},
-		{1536, "1.5 KiB"},
-		{1048576, "1.0 MiB"},
-		{1073741824, "1.0 GiB"},
-		{2684354560, "2.5 GiB"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.want, func(t *testing.T) {
-			got := formatBytes(tt.input)
-			if got != tt.want {
-				t.Errorf("formatBytes(%d) = %q, want %q", tt.input, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestFormatTimestamp(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## What

Cleanup only, no feature work:

- stdlib instead of hand-rolled: `strings.HasPrefix`/`Cut`, `slices.DeleteFunc`, `slog.Level.UnmarshalText`, `min`/`max` builtins
- one copy of the duplicated helpers: `writeJSONError`, `isHTTPS`, `settingInt`, `minPasswordLength`, `userLimitReached`
- one `writeOPML` instead of four copies of the same encoder block
- deflaked `TestRun_StartsAndShutdown`

## Why

`getClampedSetting` had parameters named `min`/`max` shadowing the builtins. The password-length and user-limit rules existed twice, once on `*API` and once on `*WebHandler` -> thats how they drift apart. `formatBytes` reimplemented `humanize.IBytes`, already a dependency.

Last commit is unrelated to the refactor, it just bit this PR: `TestRun_StartsAndShutdown` slept 100ms and assumed the listener was up -> flaked once in CI, passed on rerun with no code change. It also swallowed `errCh`, so a startup failure would surface as "connection refused" instead of the real error. Drop that commit if you want it separate.

