### PR TITLE
refactor(web): rename "goPodder users" to "sync logins"

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -2,11 +2,13 @@
 
 The goPodder API allows you to programmatically manage your podcast synchronization data. Use it to build automation scripts, custom integrations, or third-party tools that interact with your goPodder instance.
 
+**Terminology:** the `/api/v1/users` endpoints manage what the web UI calls **sync logins** — the username and password a podcast app syncs with. The `/api/v1/accounts` endpoints manage **accounts**, the logins for the web UI itself. The API paths keep the `users` spelling for backwards compatibility.
+
 ## Quick Start
 
 ```bash
 # Create an API key in the web UI: Account > API Keys > Create Key
-# Then use it to list your gPodder users:
+# Then use it to list your sync logins:
 curl -H "Authorization: Bearer gp_your_key_here" https://your-instance/api/v1/users
 ```
 
@@ -24,7 +26,7 @@ API keys are created in the web UI under **Account > API Keys**. The key is show
 
 | Role | Access |
 |------|--------|
-| `standard` | Manage your own account's gPodder users, devices, and subscriptions |
+| `standard` | Manage your own account's sync logins, devices, and subscriptions |
 | `admin` | Everything above, plus manage all accounts on the instance |
 
 Admin keys can only be created by admin accounts. Standard keys are scoped to the account that created them.
@@ -58,7 +60,7 @@ All error responses return JSON with an `error` field:
 
 #### List Users
 
-Returns all gPodder users belonging to your account.
+Returns all sync logins belonging to your account.
 
 ```
 GET /api/v1/users
@@ -92,7 +94,7 @@ curl -H "Authorization: Bearer gp_your_key" https://your-instance/api/v1/users
 
 #### Create User
 
-Creates a new gPodder user linked to your account.
+Creates a new sync login linked to your account.
 
 ```
 POST /api/v1/users
@@ -139,7 +141,7 @@ curl -X POST -H "Authorization: Bearer gp_your_key" \
 
 #### Delete User
 
-Deletes a gPodder user and all associated data (devices, subscriptions, episode actions).
+Deletes a sync login and all associated data (devices, subscriptions, episode actions).
 
 ```
 DELETE /api/v1/users/{username}
@@ -331,7 +333,7 @@ GET /api/v1/accounts
 ]
 ```
 
-The `last_login` field shows when the account last logged into the web UI. The `last_activity` field shows the most recent sync activity across all gPodder users linked to the account. Both are omitted if never occurred.
+The `last_login` field shows when the account last logged into the web UI. The `last_activity` field shows the most recent sync activity across all sync logins linked to the account. Both are omitted if never occurred.
 
 ---
 
@@ -390,7 +392,7 @@ DELETE /api/v1/accounts/{id}
 
 #### List Account Users
 
-Returns all gPodder users belonging to a specific account.
+Returns all sync logins belonging to a specific account.
 
 ```
 GET /api/v1/accounts/{id}/users

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ goPodder does one thing: it keeps your podcast subscriptions and episode progres
 ## Features
 
 - Works with [AntennaPod](https://antennapod.org/), [gPodder](https://gpodder.github.io/), [Cardo](https://github.com/cardo-podcast/cardo), and anything else that speaks the [gPodder sync protocol](https://gpoddernet.readthedocs.io/en/latest/api/)
-- Built-in web UI for managing accounts, users, devices, and subscriptions
+- Built-in web UI for managing accounts, sync logins, devices, and subscriptions
 - [REST API](APIDOCS.md) with API key auth for scripts, provisioning, and custom integrations
-- Multi-user support with admin/standard roles, per-account user limits, optional self-registration
+- Multi-account support with admin/standard roles, per-account sync login limits, optional self-registration
 - SQLite by default (zero config), PostgreSQL if you need it
 - Share your subscriptions publicly via OPML and RSS links
 - No outbound connections. The server never phones home, never fetches feed URLs, never resolves external DNS. Your subscription data stays on your box
@@ -39,7 +39,7 @@ goPodder is a single binary with a built-in web UI, multi-user support, and SQLi
 docker run --rm -p 8080:8080 ghcr.io/cbrgm/gopodder:latest
 ```
 
-Open `http://localhost:8080` in your browser. On first launch you'll be asked to create an admin account. After that, create a goPodder user from the web UI and point your podcast app at the server.
+Open `http://localhost:8080` in your browser. On first launch you'll be asked to create an admin account. After that, create a sync login from the web UI and point your podcast app at the server.
 
 ## Setup
 
@@ -128,10 +128,10 @@ The password is injected into the connection string at startup. Special characte
 
 ## Connecting your podcast app
 
-1. Create a goPodder user in the web UI (under the "Users" tab)
+1. Create a sync login in the web UI (under the "Sync Logins" tab)
 2. In your podcast app, look for "gPodder.net sync" or "Synchronize subscriptions"
 3. Set the server URL to `https://your-server`
-4. Log in with the goPodder user credentials you created
+4. Log in with the sync login username and password you created
 
 **Note:** Some clients (like AntennaPod) require HTTPS. goPodder itself does not terminate TLS, so you'll need to run it behind a reverse proxy like [Caddy](https://caddyserver.com/) or [nginx](https://nginx.org/) that handles HTTPS. For quick testing, tunnels like [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/), [Tailscale Funnel](https://tailscale.com/kb/1223/funnel), or [ngrok](https://ngrok.com/) work but a reverse proxy is the proper solution for permanent setups
 
@@ -227,7 +227,7 @@ No. The server never makes outbound network connections. It stores your feed URL
 
 ## REST API
 
-goPodder provides a REST API for programmatic access to manage users, subscriptions, and accounts. Create API keys in the web UI under **Account > API Keys** and authenticate with a Bearer token:
+goPodder provides a REST API for programmatic access to manage sync logins, subscriptions, and accounts. Create API keys in the web UI under **Account > API Keys** and authenticate with a Bearer token:
 
 ```bash
 curl -H "Authorization: Bearer gp_your_key_here" https://your-server/api/v1/users
@@ -266,7 +266,7 @@ graph LR
     STORE <--> DB
 ```
 
-Podcast apps sync subscriptions and episode progress over HTTP using the gPodder-compatible sync API. The web UI and its management API handle account, user, and subscription administration. Both talk to the same store layer, which supports SQLite or PostgreSQL
+Podcast apps sync subscriptions and episode progress over HTTP using the gPodder-compatible sync API. The web UI and its management API handle account, sync login, and subscription administration. Both talk to the same store layer, which supports SQLite or PostgreSQL
 
 ## Building from source
 

--- a/gopodder/web/layout.templ
+++ b/gopodder/web/layout.templ
@@ -92,7 +92,7 @@ templ navbar(username string, isAdmin bool, activeTab string) {
 	<nav>
 		<span class="brand">🎧 goPodder</span>
 		if username != "" {
-			<a href="/users" class={ "tab", templ.KV("active", activeTab == "users") }>Users</a>
+			<a href="/users" class={ "tab", templ.KV("active", activeTab == "users") }>Sync Logins</a>
 			if isAdmin {
 				<a href="/admin/accounts" class={ "tab", templ.KV("active", activeTab == "accounts") }>Accounts</a>
 				<a href="/admin/settings" class={ "tab", templ.KV("active", activeTab == "settings") }>Settings</a>

--- a/gopodder/web/layout_templ.go
+++ b/gopodder/web/layout_templ.go
@@ -36,7 +36,7 @@ func csrfField() templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.ResolveAttributeValue(CSRFToken(ctx))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/layout.templ`, Line: 4, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 4, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var2)
 		if templ_7745c5c3_Err != nil {
@@ -117,13 +117,13 @@ func navbar(username string, isAdmin bool, activeTab string) templ.Component {
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var5).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/layout.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\">Users</a> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\">Sync Logins</a> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -140,7 +140,7 @@ func navbar(username string, isAdmin bool, activeTab string) templ.Component {
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var7).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/layout.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
 				if templ_7745c5c3_Err != nil {
@@ -162,7 +162,7 @@ func navbar(username string, isAdmin bool, activeTab string) templ.Component {
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var9).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/layout.templ`, Line: 1, Col: 0}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var10)
 				if templ_7745c5c3_Err != nil {
@@ -189,7 +189,7 @@ func navbar(username string, isAdmin bool, activeTab string) templ.Component {
 			var templ_7745c5c3_Var12 string
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var11).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/layout.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var12)
 			if templ_7745c5c3_Err != nil {
@@ -202,7 +202,7 @@ func navbar(username string, isAdmin bool, activeTab string) templ.Component {
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(username)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/layout.templ`, Line: 103, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 103, Col: 14}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -379,7 +379,7 @@ func alertError(msg string) templ.Component {
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(msg)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/layout.templ`, Line: 150, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 150, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
@@ -423,7 +423,7 @@ func alertSuccess(msg string) templ.Component {
 			var templ_7745c5c3_Var19 string
 			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(msg)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/layout.templ`, Line: 156, Col: 34}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `layout.templ`, Line: 156, Col: 34}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {

--- a/gopodder/web/pages.templ
+++ b/gopodder/web/pages.templ
@@ -28,7 +28,7 @@ templ SetupPage(errMsg string) {
 				<button type="submit" class="btn btn-primary">Get Started</button>
 			</div>
 		</form>
-		<p class="setting-desc" style="margin-top: 20px; text-align: center;">Next: go to Users, create a goPodder user, then log in with that username and password in your podcast app.</p>
+		<p class="setting-desc" style="margin-top: 20px; text-align: center;">Next: go to Sync Logins, create one, then enter that username and password in your podcast app.</p>
 	}
 }
 
@@ -133,7 +133,7 @@ templ StatusPage(data StatusData) {
 					<td>{ fmt.Sprint(data.Stats.Accounts) }</td>
 				</tr>
 				<tr>
-					<th>goPodder Users</th>
+					<th>Sync Logins</th>
 					<td>{ fmt.Sprint(data.Stats.Users) }</td>
 				</tr>
 				<tr>
@@ -163,7 +163,7 @@ templ StatusPage(data StatusData) {
 templ AccountsPage(data AccountsPageData) {
 	@layout(data.Account, true, "accounts") {
 		<h1>Accounts</h1>
-		<p class="page-desc">Accounts are used to log in to this web interface. Each account can have one or more goPodder users linked to it for podcast synchronization.</p>
+		<p class="page-desc">Accounts log in to this web interface. Each account can have one or more sync logins for podcast apps.</p>
 		@alertError(data.Error)
 		@alertSuccess(data.Flash)
 		<div class="section">
@@ -196,7 +196,7 @@ templ AccountsPage(data AccountsPageData) {
 				<tr>
 					<th>Account Name</th>
 					<th>Role</th>
-					<th>goPodder Users</th>
+					<th>Sync Logins</th>
 					<th>Created</th>
 					<th>Last Login</th>
 					<th>Last Activity</th>
@@ -280,9 +280,9 @@ templ AccountEditPage(data AccountEditData) {
 			</form>
 		</div>
 		<div class="section">
-			<h2>goPodder Users</h2>
+			<h2>Sync Logins</h2>
 			if len(data.Users) == 0 {
-				<p>No goPodder users linked to this account.</p>
+				<p>No sync logins for this account.</p>
 			} else {
 				<div class="table-wrap">
 					<table>
@@ -302,7 +302,7 @@ templ AccountEditPage(data AccountEditData) {
 								<td>
 									<div class="btn-group">
 										<a href={ templ.SafeURL("/admin/accounts/" + data.EditAccount.ID + "/users/" + user.Username) } class="btn">Details</a>
-										<form method="POST" action={ templ.SafeURL("/admin/accounts/" + data.EditAccount.ID + "/users/" + user.Username + "/delete") } style="display:inline;" onsubmit="return confirm('Delete this user? This cannot be undone.');">
+										<form method="POST" action={ templ.SafeURL("/admin/accounts/" + data.EditAccount.ID + "/users/" + user.Username + "/delete") } style="display:inline;" onsubmit="return confirm('Delete this sync login? This cannot be undone.');">
 											@csrfField()
 											<button type="submit" class="btn btn-danger">Delete</button>
 										</form>
@@ -313,7 +313,7 @@ templ AccountEditPage(data AccountEditData) {
 					</table>
 				</div>
 			}
-			<h3>Create goPodder User</h3>
+			<h3>Create Sync Login</h3>
 			<form method="POST" action={ templ.SafeURL("/admin/accounts/" + data.EditAccount.ID + "/users") }>
 				@csrfField()
 				<div class="form-row">
@@ -326,7 +326,7 @@ templ AccountEditPage(data AccountEditData) {
 				</div>
 				<div class="form-row">
 					<label></label>
-					<button type="submit" class="btn btn-primary">Create User</button>
+					<button type="submit" class="btn btn-primary">Create Sync Login</button>
 				</div>
 			</form>
 		</div>
@@ -374,13 +374,13 @@ templ UserDetailPage(data UserDetailData) {
 		if data.ActiveTab == "accounts" {
 			<h1>Accounts / { data.AccountName } / { data.Username }</h1>
 		} else {
-			<h1>Users / { data.Username }</h1>
+			<h1>Sync Logins / { data.Username }</h1>
 		}
 		@alertError(data.Error)
 		@alertSuccess(data.Flash)
 		<div class="section">
 			<h2>Devices</h2>
-			<p class="setting-desc">Devices register automatically when your podcast app syncs and share the same subscriptions. Removing one here cleans up the list, but it will reappear on the next sync unless you change the user's password.</p>
+			<p class="setting-desc">Devices register automatically when your podcast app syncs and share the same subscriptions. Removing one here cleans up the list, but it will reappear on the next sync unless you change the sync login's password.</p>
 			if len(data.Devices) == 0 {
 				<p>No devices registered yet.</p>
 			} else {
@@ -521,7 +521,7 @@ templ UserDetailPage(data UserDetailData) {
 		}
 		<div class="section">
 			<h2>Change Password</h2>
-			<p class="setting-desc">Change the password for this goPodder user. This is the password used by podcast apps to authenticate with the sync server.</p>
+			<p class="setting-desc">Change the password for this sync login. Podcast apps use it to authenticate with the sync server.</p>
 			<form method="POST" action={ templ.SafeURL(data.BasePath + "/password") }>
 				@csrfField()
 				<div class="form-row">
@@ -544,13 +544,13 @@ templ UserDetailPage(data UserDetailData) {
 
 templ UserManagementPage(data UserManagementData) {
 	@layout(data.Account, data.IsAdmin, "users") {
-		<h1>Users</h1>
-		<p class="page-desc">goPodder users are the credentials your podcast apps use to log in and sync. Enter these in your app's gPodder sync settings (username and password) along with your server URL. Each user can be connected to multiple devices.</p>
+		<h1>Sync Logins</h1>
+		<p class="page-desc">A sync login is the username and password your podcast app uses to sync. Enter these in your app's gPodder sync settings along with your server URL. Each sync login can be connected to multiple devices.</p>
 		@alertError(data.Error)
 		@alertSuccess(data.Flash)
 		if data.CanCreateUsers {
 			<div class="section">
-				<h2>Create goPodder User</h2>
+				<h2>Create Sync Login</h2>
 				<form method="POST" action="/users">
 					@csrfField()
 					<div class="form-row">
@@ -563,15 +563,15 @@ templ UserManagementPage(data UserManagementData) {
 					</div>
 					<div class="form-row">
 						<label></label>
-						<button type="submit" class="btn btn-primary">Create User</button>
+						<button type="submit" class="btn btn-primary">Create Sync Login</button>
 					</div>
 				</form>
 			</div>
 		}
 		if len(data.Users) == 0 {
-			<p>No goPodder users linked to your account.</p>
+			<p>No sync logins for your account.</p>
 			if !data.CanCreateUsers {
-				<p class="setting-desc">Contact an administrator to have goPodder users created for your account.</p>
+				<p class="setting-desc">Contact an administrator to have sync logins created for your account.</p>
 			}
 		} else {
 			<div class="table-wrap">
@@ -595,7 +595,7 @@ templ UserManagementPage(data UserManagementData) {
 									if user.Subscriptions > 0 {
 										<a href={ templ.SafeURL("/opml?user=" + user.Username) } class="btn" title="Export all subscriptions of this user as OPML">Export OPML</a>
 									}
-									<form method="POST" action={ templ.SafeURL("/users/" + user.Username + "/delete") } style="display:inline;" onsubmit="return confirm('Delete this user? This cannot be undone.');">
+									<form method="POST" action={ templ.SafeURL("/users/" + user.Username + "/delete") } style="display:inline;" onsubmit="return confirm('Delete this sync login? This cannot be undone.');">
 										@csrfField()
 										<button type="submit" class="btn btn-danger">Delete</button>
 									</form>
@@ -612,7 +612,7 @@ templ UserManagementPage(data UserManagementData) {
 templ SettingsPage(data SettingsPageData) {
 	@layout(data.Account, true, "settings") {
 		<h1>Settings</h1>
-		<p class="page-desc">Configure how goPodder behaves. Changes take effect immediately for all users.</p>
+		<p class="page-desc">Configure how goPodder behaves. Changes take effect immediately for all accounts.</p>
 		@alertError(data.Error)
 		@alertSuccess(data.Flash)
 		<form method="POST" action="/admin/settings">
@@ -636,7 +636,7 @@ templ SettingsPage(data SettingsPageData) {
 				<p class="setting-desc">When enabled, a "Register" button is shown on the login page. Anyone can create their own account without admin intervention. Self-registered accounts are assigned the "standard" role.</p>
 			</div>
 			<div class="section">
-				<h2>User Management</h2>
+				<h2>Sync Logins</h2>
 				<div class="setting-item">
 					<label for="allow-user-creation">
 						<input
@@ -648,15 +648,15 @@ templ SettingsPage(data SettingsPageData) {
 								checked
 							}
 						/>
-						Allow users to create goPodder users
+						Allow accounts to create their own sync logins
 					</label>
 				</div>
-				<p class="setting-desc">When enabled, standard accounts can create and manage their own goPodder users from the Users tab. When disabled, only admins can create goPodder users for accounts.</p>
+				<p class="setting-desc">When enabled, standard accounts can create and manage their own sync logins from the Sync Logins tab. When disabled, only admins can create sync logins for accounts.</p>
 				<div class="setting-item">
-					<label for="max-users">Max goPodder users per account</label>
+					<label for="max-users">Max sync logins per account</label>
 					<input type="number" id="max-users" name="max_users_per_account" value={ fmt.Sprint(data.MaxUsersPerAccount) } min="0"/>
 				</div>
-				<p class="setting-desc">Maximum number of goPodder users each account can create. Set to 0 for unlimited.</p>
+				<p class="setting-desc">Maximum number of sync logins each account can create. Set to 0 for unlimited.</p>
 				<div class="setting-item">
 					<label for="allow-sharing">
 						<input
@@ -671,7 +671,7 @@ templ SettingsPage(data SettingsPageData) {
 						Allow subscription sharing
 					</label>
 				</div>
-				<p class="setting-desc">When enabled, users can generate public links to share their subscriptions as OPML or RSS feeds. When disabled, sharing is not available and existing share links stop working.</p>
+				<p class="setting-desc">When enabled, accounts can generate public links to share their subscriptions as OPML or RSS feeds. When disabled, sharing is not available and existing share links stop working.</p>
 				<div class="setting-item">
 					<label for="allow-api-keys">
 						<input
@@ -699,7 +699,7 @@ templ SettingsPage(data SettingsPageData) {
 					<label for="min-pw-length">Minimum password length</label>
 					<input type="number" id="min-pw-length" name="min_password_length" value={ fmt.Sprint(data.MinPasswordLength) } min="0"/>
 				</div>
-				<p class="setting-desc">Minimum number of characters required for all passwords (accounts and goPodder users). Default is 8. Setting this below 8 weakens security and is not recommended.</p>
+				<p class="setting-desc">Minimum number of characters required for all passwords (accounts and sync logins). Default is 8. Setting this below 8 weakens security and is not recommended.</p>
 				<div class="setting-item">
 					<label for="session-max-age">Session max age (hours)</label>
 					<input type="number" id="session-max-age" name="session_max_age_hours" value={ fmt.Sprint(data.SessionMaxAge) } min="1"/>
@@ -766,7 +766,7 @@ templ AccountSelfPage(data AccountSelfData) {
 		if data.APIKeysAllowed {
 			<div class="section">
 				<h2>API Keys</h2>
-				<p class="setting-desc">API keys allow programmatic access to manage goPodder users and subscriptions. Authenticate with a Bearer token in the Authorization header.</p>
+				<p class="setting-desc">API keys allow programmatic access to manage sync logins and subscriptions. Authenticate with a Bearer token in the Authorization header.</p>
 				<p class="setting-desc"><a href={ templ.SafeURL(RepoURL + "/blob/main/APIDOCS.md") } target="_blank">View API documentation</a></p>
 				if len(data.APIKeys) > 0 {
 					<div class="table-wrap">
@@ -824,7 +824,7 @@ templ AccountSelfPage(data AccountSelfData) {
 		}
 		<div class="section">
 			<h2>Delete Account</h2>
-			<p class="setting-desc">Permanently delete your account and all associated goPodder users, devices, and subscriptions. This cannot be undone.</p>
+			<p class="setting-desc">Permanently delete your account and all associated sync logins, devices, and subscriptions. This cannot be undone.</p>
 			<form method="POST" action="/account/delete" onsubmit="return confirm('Are you sure you want to delete your account? All data will be permanently lost.');">
 				@csrfField()
 				<div class="form-row">

--- a/gopodder/web/pages_templ.go
+++ b/gopodder/web/pages_templ.go
@@ -53,7 +53,7 @@ func SetupPage(errMsg string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, " <form method=\"POST\" action=\"/setup\"><div class=\"form-row\"><label for=\"username\">Username</label> <input type=\"text\" id=\"username\" name=\"username\" required autofocus></div><div class=\"form-row\"><label for=\"password\">Password</label> <input type=\"password\" id=\"password\" name=\"password\" required></div><div class=\"form-row\"><label for=\"password2\">Confirm</label> <input type=\"password\" id=\"password2\" name=\"password2\" required></div><div class=\"form-row\"><label></label> <button type=\"submit\" class=\"btn btn-primary\">Get Started</button></div></form><p class=\"setting-desc\" style=\"margin-top: 20px; text-align: center;\">Next: go to Users, create a goPodder user, then log in with that username and password in your podcast app.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, " <form method=\"POST\" action=\"/setup\"><div class=\"form-row\"><label for=\"username\">Username</label> <input type=\"text\" id=\"username\" name=\"username\" required autofocus></div><div class=\"form-row\"><label for=\"password\">Password</label> <input type=\"password\" id=\"password\" name=\"password\" required></div><div class=\"form-row\"><label for=\"password2\">Confirm</label> <input type=\"password\" id=\"password2\" name=\"password2\" required></div><div class=\"form-row\"><label></label> <button type=\"submit\" class=\"btn btn-primary\">Get Started</button></div></form><p class=\"setting-desc\" style=\"margin-top: 20px; text-align: center;\">Next: go to Sync Logins, create one, then enter that username and password in your podcast app.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -130,7 +130,7 @@ func LoginPage(errMsg string, showRegister bool, version string) templ.Component
 				var templ_7745c5c3_Var5 string
 				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(version)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 60, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 60, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 				if templ_7745c5c3_Err != nil {
@@ -148,7 +148,7 @@ func LoginPage(errMsg string, showRegister bool, version string) templ.Component
 			var templ_7745c5c3_Var6 templ.SafeURL
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(RepoURL))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 63, Col: 36}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 63, Col: 36}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -161,7 +161,7 @@ func LoginPage(errMsg string, showRegister bool, version string) templ.Component
 			var templ_7745c5c3_Var7 templ.SafeURL
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(RepoURL + "/releases"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 64, Col: 50}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 64, Col: 50}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -174,7 +174,7 @@ func LoginPage(errMsg string, showRegister bool, version string) templ.Component
 			var templ_7745c5c3_Var8 templ.SafeURL
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(RepoURL + "/issues"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 65, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 65, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -234,7 +234,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var11 templ.SafeURL
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(RepoURL))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 76, Col: 263}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 76, Col: 263}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -247,7 +247,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var12 templ.SafeURL
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(RepoURL + "/releases"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 76, Col: 349}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 76, Col: 349}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -260,7 +260,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(data.Version)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 83, Col: 23}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 83, Col: 23}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -273,7 +273,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var14 string
 			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(data.Revision)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 87, Col: 24}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 87, Col: 24}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 			if templ_7745c5c3_Err != nil {
@@ -286,7 +286,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var15 string
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(data.BuildDate)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 91, Col: 25}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 91, Col: 25}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
@@ -299,7 +299,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var16 string
 			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(data.GoVersion)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 95, Col: 25}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 95, Col: 25}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 			if templ_7745c5c3_Err != nil {
@@ -312,7 +312,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(data.Platform)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 99, Col: 24}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 99, Col: 24}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
@@ -325,7 +325,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(data.ListenAddr)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 108, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 108, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 			if templ_7745c5c3_Err != nil {
@@ -338,7 +338,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var19 string
 			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(data.DBBackend)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 112, Col: 25}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 112, Col: 25}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {
@@ -351,7 +351,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var20 string
 			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(data.Uptime)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 116, Col: 22}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 116, Col: 22}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 			if templ_7745c5c3_Err != nil {
@@ -364,7 +364,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var21 string
 			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(data.MemAlloc)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 120, Col: 24}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 120, Col: 24}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 			if templ_7745c5c3_Err != nil {
@@ -377,7 +377,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(data.Goroutines))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 124, Col: 38}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 124, Col: 38}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
@@ -390,20 +390,20 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var23 string
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(data.Stats.Accounts))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 133, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 133, Col: 42}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</td></tr><tr><th>goPodder Users</th><td>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</td></tr><tr><th>Sync Logins</th><td>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var24 string
 			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(data.Stats.Users))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 137, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 137, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
@@ -416,7 +416,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(data.Stats.Devices))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 141, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 141, Col: 41}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
@@ -429,7 +429,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var26 string
 			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(data.Stats.Subscriptions))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 145, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 145, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
@@ -442,7 +442,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var27 string
 			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(data.Stats.Episodes))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 149, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 149, Col: 42}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 			if templ_7745c5c3_Err != nil {
@@ -455,7 +455,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var28 templ.SafeURL
 			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(RepoURL))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 155, Col: 36}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 155, Col: 36}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {
@@ -468,7 +468,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var29 templ.SafeURL
 			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(RepoURL + "/releases"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 156, Col: 59}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 156, Col: 59}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 			if templ_7745c5c3_Err != nil {
@@ -481,7 +481,7 @@ func StatusPage(data StatusData) templ.Component {
 			var templ_7745c5c3_Var30 templ.SafeURL
 			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(RepoURL + "/issues"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 157, Col: 57}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 157, Col: 57}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
@@ -534,7 +534,7 @@ func AccountsPage(data AccountsPageData) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<h1>Accounts</h1><p class=\"page-desc\">Accounts are used to log in to this web interface. Each account can have one or more goPodder users linked to it for podcast synchronization.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<h1>Accounts</h1><p class=\"page-desc\">Accounts log in to this web interface. Each account can have one or more sync logins for podcast apps.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -558,7 +558,7 @@ func AccountsPage(data AccountsPageData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<div class=\"form-row\"><label for=\"new-username\">Username</label> <input type=\"text\" id=\"new-username\" name=\"username\" required></div><div class=\"form-row\"><label for=\"new-password\">Password</label> <input type=\"password\" id=\"new-password\" name=\"password\" required></div><div class=\"form-row\"><label for=\"new-role\">Role</label> <select id=\"new-role\" name=\"role\"><option value=\"standard\">standard</option> <option value=\"admin\">admin</option></select></div><div class=\"form-row\"><label></label> <button type=\"submit\" class=\"btn btn-primary\">Create Account</button></div></form></div><div class=\"table-wrap\"><table><tr><th>Account Name</th><th>Role</th><th>goPodder Users</th><th>Created</th><th>Last Login</th><th>Last Activity</th><th>Actions</th></tr>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<div class=\"form-row\"><label for=\"new-username\">Username</label> <input type=\"text\" id=\"new-username\" name=\"username\" required></div><div class=\"form-row\"><label for=\"new-password\">Password</label> <input type=\"password\" id=\"new-password\" name=\"password\" required></div><div class=\"form-row\"><label for=\"new-role\">Role</label> <select id=\"new-role\" name=\"role\"><option value=\"standard\">standard</option> <option value=\"admin\">admin</option></select></div><div class=\"form-row\"><label></label> <button type=\"submit\" class=\"btn btn-primary\">Create Account</button></div></form></div><div class=\"table-wrap\"><table><tr><th>Account Name</th><th>Role</th><th>Sync Logins</th><th>Created</th><th>Last Login</th><th>Last Activity</th><th>Actions</th></tr>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -570,7 +570,7 @@ func AccountsPage(data AccountsPageData) templ.Component {
 				var templ_7745c5c3_Var33 string
 				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(acct.Username)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 207, Col: 25}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 207, Col: 25}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 				if templ_7745c5c3_Err != nil {
@@ -583,7 +583,7 @@ func AccountsPage(data AccountsPageData) templ.Component {
 				var templ_7745c5c3_Var34 string
 				templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(acct.Role)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 208, Col: 21}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 208, Col: 21}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 				if templ_7745c5c3_Err != nil {
@@ -596,7 +596,7 @@ func AccountsPage(data AccountsPageData) templ.Component {
 				var templ_7745c5c3_Var35 string
 				templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(acct.Users))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 209, Col: 34}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 209, Col: 34}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 				if templ_7745c5c3_Err != nil {
@@ -609,7 +609,7 @@ func AccountsPage(data AccountsPageData) templ.Component {
 				var templ_7745c5c3_Var36 string
 				templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(acct.CreatedAt)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 210, Col: 40}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 210, Col: 40}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 				if templ_7745c5c3_Err != nil {
@@ -622,7 +622,7 @@ func AccountsPage(data AccountsPageData) templ.Component {
 				var templ_7745c5c3_Var37 string
 				templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(acct.LastLogin)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 211, Col: 40}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 211, Col: 40}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 				if templ_7745c5c3_Err != nil {
@@ -635,7 +635,7 @@ func AccountsPage(data AccountsPageData) templ.Component {
 				var templ_7745c5c3_Var38 string
 				templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(acct.LastActivity)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 212, Col: 43}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 212, Col: 43}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 				if templ_7745c5c3_Err != nil {
@@ -648,7 +648,7 @@ func AccountsPage(data AccountsPageData) templ.Component {
 				var templ_7745c5c3_Var39 templ.SafeURL
 				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/admin/accounts/" + acct.ID))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 215, Col: 61}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 215, Col: 61}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 				if templ_7745c5c3_Err != nil {
@@ -666,7 +666,7 @@ func AccountsPage(data AccountsPageData) templ.Component {
 					var templ_7745c5c3_Var40 templ.SafeURL
 					templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/admin/accounts/" + acct.ID + "/delete"))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 217, Col: 93}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 217, Col: 93}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 					if templ_7745c5c3_Err != nil {
@@ -744,7 +744,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 			var templ_7745c5c3_Var43 string
 			templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(data.EditAccount.Username)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 233, Col: 44}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 233, Col: 44}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 			if templ_7745c5c3_Err != nil {
@@ -773,7 +773,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 			var templ_7745c5c3_Var44 templ.SafeURL
 			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/admin/accounts/" + data.EditAccount.ID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 239, Col: 87}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 239, Col: 87}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 			if templ_7745c5c3_Err != nil {
@@ -794,7 +794,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 			var templ_7745c5c3_Var45 string
 			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.ResolveAttributeValue(data.EditAccount.Username)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 243, Col: 88}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 243, Col: 88}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var45)
 			if templ_7745c5c3_Err != nil {
@@ -822,7 +822,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 			var templ_7745c5c3_Var46 templ.SafeURL
 			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/admin/accounts/" + data.EditAccount.ID + "/password"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 266, Col: 101}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 266, Col: 101}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 			if templ_7745c5c3_Err != nil {
@@ -836,12 +836,12 @@ func AccountEditPage(data AccountEditData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "<div class=\"form-row\"><label for=\"new-pw\">New Password</label> <input type=\"password\" id=\"new-pw\" name=\"password\" required></div><div class=\"form-row\"><label for=\"new-pw2\">Confirm</label> <input type=\"password\" id=\"new-pw2\" name=\"password2\" required></div><div class=\"form-row\"><label></label> <button type=\"submit\" class=\"btn btn-primary\">Change Password</button></div></form></div><div class=\"section\"><h2>goPodder Users</h2>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "<div class=\"form-row\"><label for=\"new-pw\">New Password</label> <input type=\"password\" id=\"new-pw\" name=\"password\" required></div><div class=\"form-row\"><label for=\"new-pw2\">Confirm</label> <input type=\"password\" id=\"new-pw2\" name=\"password2\" required></div><div class=\"form-row\"><label></label> <button type=\"submit\" class=\"btn btn-primary\">Change Password</button></div></form></div><div class=\"section\"><h2>Sync Logins</h2>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if len(data.Users) == 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "<p>No goPodder users linked to this account.</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "<p>No sync logins for this account.</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -858,7 +858,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 					var templ_7745c5c3_Var47 string
 					templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(user.Username)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 298, Col: 27}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 298, Col: 27}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 					if templ_7745c5c3_Err != nil {
@@ -871,7 +871,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 					var templ_7745c5c3_Var48 string
 					templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(user.Devices))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 299, Col: 38}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 299, Col: 38}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 					if templ_7745c5c3_Err != nil {
@@ -884,7 +884,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 					var templ_7745c5c3_Var49 string
 					templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(user.Subscriptions))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 300, Col: 44}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 300, Col: 44}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 					if templ_7745c5c3_Err != nil {
@@ -897,7 +897,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 					var templ_7745c5c3_Var50 string
 					templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(user.LastActivity)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 301, Col: 45}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 301, Col: 45}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 					if templ_7745c5c3_Err != nil {
@@ -910,7 +910,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 					var templ_7745c5c3_Var51 templ.SafeURL
 					templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/admin/accounts/" + data.EditAccount.ID + "/users/" + user.Username))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 304, Col: 103}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 304, Col: 103}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 					if templ_7745c5c3_Err != nil {
@@ -923,13 +923,13 @@ func AccountEditPage(data AccountEditData) templ.Component {
 					var templ_7745c5c3_Var52 templ.SafeURL
 					templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/admin/accounts/" + data.EditAccount.ID + "/users/" + user.Username + "/delete"))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 305, Col: 134}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 305, Col: 134}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "\" style=\"display:inline;\" onsubmit=\"return confirm('Delete this user? This cannot be undone.');\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "\" style=\"display:inline;\" onsubmit=\"return confirm('Delete this sync login? This cannot be undone.');\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -947,14 +947,14 @@ func AccountEditPage(data AccountEditData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "<h3>Create goPodder User</h3><form method=\"POST\" action=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "<h3>Create Sync Login</h3><form method=\"POST\" action=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var53 templ.SafeURL
 			templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/admin/accounts/" + data.EditAccount.ID + "/users"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 317, Col: 98}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 317, Col: 98}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 			if templ_7745c5c3_Err != nil {
@@ -968,7 +968,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "<div class=\"form-row\"><label for=\"gpuser\">Username</label> <input type=\"text\" id=\"gpuser\" name=\"username\" required></div><div class=\"form-row\"><label for=\"gppass\">Password</label> <input type=\"password\" id=\"gppass\" name=\"password\" required></div><div class=\"form-row\"><label></label> <button type=\"submit\" class=\"btn btn-primary\">Create User</button></div></form></div><div class=\"section\"><h2>API Keys</h2><p class=\"setting-desc\">API keys belonging to this account. Revoking a key will immediately disconnect any application using it.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "<div class=\"form-row\"><label for=\"gpuser\">Username</label> <input type=\"text\" id=\"gpuser\" name=\"username\" required></div><div class=\"form-row\"><label for=\"gppass\">Password</label> <input type=\"password\" id=\"gppass\" name=\"password\" required></div><div class=\"form-row\"><label></label> <button type=\"submit\" class=\"btn btn-primary\">Create Sync Login</button></div></form></div><div class=\"section\"><h2>API Keys</h2><p class=\"setting-desc\">API keys belonging to this account. Revoking a key will immediately disconnect any application using it.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -990,7 +990,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 					var templ_7745c5c3_Var54 string
 					templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(key.Name)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 351, Col: 22}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 351, Col: 22}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 					if templ_7745c5c3_Err != nil {
@@ -1003,7 +1003,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 					var templ_7745c5c3_Var55 string
 					templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(key.Prefix)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 352, Col: 37}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 352, Col: 37}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 					if templ_7745c5c3_Err != nil {
@@ -1016,7 +1016,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 					var templ_7745c5c3_Var56 string
 					templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(key.Role)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 353, Col: 22}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 353, Col: 22}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 					if templ_7745c5c3_Err != nil {
@@ -1029,7 +1029,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 					var templ_7745c5c3_Var57 string
 					templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(key.CreatedAt)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 354, Col: 41}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 354, Col: 41}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 					if templ_7745c5c3_Err != nil {
@@ -1042,7 +1042,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 					var templ_7745c5c3_Var58 string
 					templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(key.LastUsed)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 355, Col: 40}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 355, Col: 40}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 					if templ_7745c5c3_Err != nil {
@@ -1055,7 +1055,7 @@ func AccountEditPage(data AccountEditData) templ.Component {
 					var templ_7745c5c3_Var59 templ.SafeURL
 					templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/admin/accounts/" + data.EditAccount.ID + "/keys/" + key.ID + "/delete"))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 357, Col: 125}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 357, Col: 125}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 					if templ_7745c5c3_Err != nil {
@@ -1134,7 +1134,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 				var templ_7745c5c3_Var62 string
 				templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(data.AccountName)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 375, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 375, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
 				if templ_7745c5c3_Err != nil {
@@ -1147,7 +1147,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 				var templ_7745c5c3_Var63 string
 				templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(data.Username)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 375, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 375, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
 				if templ_7745c5c3_Err != nil {
@@ -1158,14 +1158,14 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "<h1>Users / ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "<h1>Sync Logins / ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var64 string
 				templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(data.Username)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 377, Col: 30}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 377, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
 				if templ_7745c5c3_Err != nil {
@@ -1192,7 +1192,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, " <div class=\"section\"><h2>Devices</h2><p class=\"setting-desc\">Devices register automatically when your podcast app syncs and share the same subscriptions. Removing one here cleans up the list, but it will reappear on the next sync unless you change the user's password.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, " <div class=\"section\"><h2>Devices</h2><p class=\"setting-desc\">Devices register automatically when your podcast app syncs and share the same subscriptions. Removing one here cleans up the list, but it will reappear on the next sync unless you change the sync login's password.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1214,7 +1214,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var65 string
 					templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(dev.ID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 398, Col: 33}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 398, Col: 33}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
 					if templ_7745c5c3_Err != nil {
@@ -1227,7 +1227,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var66 string
 					templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(dev.Caption)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 399, Col: 25}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 399, Col: 25}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
 					if templ_7745c5c3_Err != nil {
@@ -1240,7 +1240,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var67 string
 					templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(dev.Type)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 400, Col: 22}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 400, Col: 22}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
 					if templ_7745c5c3_Err != nil {
@@ -1253,7 +1253,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var68 string
 					templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(dev.LastActivity)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 401, Col: 44}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 401, Col: 44}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
 					if templ_7745c5c3_Err != nil {
@@ -1266,7 +1266,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var69 templ.SafeURL
 					templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.BasePath + "/devices/" + dev.ID + "/delete"))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 403, Col: 101}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 403, Col: 101}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
 					if templ_7745c5c3_Err != nil {
@@ -1312,7 +1312,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var70 string
 					templ_7745c5c3_Var70, templ_7745c5c3_Err = templ.JoinStringErrs(sub)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 428, Col: 30}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 428, Col: 30}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var70))
 					if templ_7745c5c3_Err != nil {
@@ -1325,7 +1325,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var71 templ.SafeURL
 					templ_7745c5c3_Var71, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.BasePath + "/subscriptions/delete-one"))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 430, Col: 96}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 430, Col: 96}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var71))
 					if templ_7745c5c3_Err != nil {
@@ -1346,7 +1346,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var72 string
 					templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.ResolveAttributeValue(sub)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 432, Col: 53}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 432, Col: 53}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var72)
 					if templ_7745c5c3_Err != nil {
@@ -1364,7 +1364,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 				var templ_7745c5c3_Var73 templ.SafeURL
 				templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/opml?user=" + data.Username))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 442, Col: 60}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 442, Col: 60}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var73))
 				if templ_7745c5c3_Err != nil {
@@ -1377,7 +1377,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 				var templ_7745c5c3_Var74 templ.SafeURL
 				templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.BasePath + "/subscriptions/delete"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 443, Col: 89}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 443, Col: 89}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
 				if templ_7745c5c3_Err != nil {
@@ -1403,7 +1403,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 			var templ_7745c5c3_Var75 templ.SafeURL
 			templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.BasePath + "/subscriptions/add"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 452, Col: 83}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 452, Col: 83}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
 			if templ_7745c5c3_Err != nil {
@@ -1424,7 +1424,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 			var templ_7745c5c3_Var76 templ.SafeURL
 			templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.BasePath + "/subscriptions/import"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 465, Col: 86}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 465, Col: 86}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
 			if templ_7745c5c3_Err != nil {
@@ -1455,7 +1455,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var77 string
 					templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.ResolveAttributeValue(data.ShareOPMLURL)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 485, Col: 50}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 485, Col: 50}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var77)
 					if templ_7745c5c3_Err != nil {
@@ -1468,7 +1468,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var78 templ.SafeURL
 					templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.ShareOPMLURL))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 487, Col: 48}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 487, Col: 48}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
 					if templ_7745c5c3_Err != nil {
@@ -1481,7 +1481,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var79 string
 					templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.ResolveAttributeValue(data.ShareRSSURL)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 493, Col: 49}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 493, Col: 49}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var79)
 					if templ_7745c5c3_Err != nil {
@@ -1494,7 +1494,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var80 templ.SafeURL
 					templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.ShareRSSURL))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 495, Col: 47}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 495, Col: 47}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
 					if templ_7745c5c3_Err != nil {
@@ -1507,7 +1507,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var81 templ.SafeURL
 					templ_7745c5c3_Var81, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.BasePath + "/sharing/enable"))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 501, Col: 83}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 501, Col: 83}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var81))
 					if templ_7745c5c3_Err != nil {
@@ -1528,7 +1528,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var82 templ.SafeURL
 					templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.BasePath + "/sharing/disable"))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 505, Col: 84}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 505, Col: 84}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 					if templ_7745c5c3_Err != nil {
@@ -1554,7 +1554,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					var templ_7745c5c3_Var83 templ.SafeURL
 					templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.BasePath + "/sharing/enable"))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 512, Col: 81}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 512, Col: 81}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
 					if templ_7745c5c3_Err != nil {
@@ -1578,14 +1578,14 @@ func UserDetailPage(data UserDetailData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 138, " <div class=\"section\"><h2>Change Password</h2><p class=\"setting-desc\">Change the password for this goPodder user. This is the password used by podcast apps to authenticate with the sync server.</p><form method=\"POST\" action=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 138, " <div class=\"section\"><h2>Change Password</h2><p class=\"setting-desc\">Change the password for this sync login. Podcast apps use it to authenticate with the sync server.</p><form method=\"POST\" action=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var84 templ.SafeURL
 			templ_7745c5c3_Var84, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.BasePath + "/password"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 525, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 525, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var84))
 			if templ_7745c5c3_Err != nil {
@@ -1606,7 +1606,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 			var templ_7745c5c3_Var85 templ.SafeURL
 			templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.BackURL))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 541, Col: 60}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 541, Col: 60}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
 			if templ_7745c5c3_Err != nil {
@@ -1619,7 +1619,7 @@ func UserDetailPage(data UserDetailData) templ.Component {
 			var templ_7745c5c3_Var86 string
 			templ_7745c5c3_Var86, templ_7745c5c3_Err = templ.JoinStringErrs(data.BackLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 541, Col: 91}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 541, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var86))
 			if templ_7745c5c3_Err != nil {
@@ -1672,7 +1672,7 @@ func UserManagementPage(data UserManagementData) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 143, "<h1>Users</h1><p class=\"page-desc\">goPodder users are the credentials your podcast apps use to log in and sync. Enter these in your app's gPodder sync settings (username and password) along with your server URL. Each user can be connected to multiple devices.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 143, "<h1>Sync Logins</h1><p class=\"page-desc\">A sync login is the username and password your podcast app uses to sync. Enter these in your app's gPodder sync settings along with your server URL. Each sync login can be connected to multiple devices.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1693,7 +1693,7 @@ func UserManagementPage(data UserManagementData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if data.CanCreateUsers {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 146, "<div class=\"section\"><h2>Create goPodder User</h2><form method=\"POST\" action=\"/users\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 146, "<div class=\"section\"><h2>Create Sync Login</h2><form method=\"POST\" action=\"/users\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1701,7 +1701,7 @@ func UserManagementPage(data UserManagementData) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 147, "<div class=\"form-row\"><label for=\"gpuser\">Username</label> <input type=\"text\" id=\"gpuser\" name=\"username\" required></div><div class=\"form-row\"><label for=\"gppass\">Password</label> <input type=\"password\" id=\"gppass\" name=\"password\" required></div><div class=\"form-row\"><label></label> <button type=\"submit\" class=\"btn btn-primary\">Create User</button></div></form></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 147, "<div class=\"form-row\"><label for=\"gpuser\">Username</label> <input type=\"text\" id=\"gpuser\" name=\"username\" required></div><div class=\"form-row\"><label for=\"gppass\">Password</label> <input type=\"password\" id=\"gppass\" name=\"password\" required></div><div class=\"form-row\"><label></label> <button type=\"submit\" class=\"btn btn-primary\">Create Sync Login</button></div></form></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1711,12 +1711,12 @@ func UserManagementPage(data UserManagementData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if len(data.Users) == 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 149, "<p>No goPodder users linked to your account.</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 149, "<p>No sync logins for your account.</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if !data.CanCreateUsers {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 150, "<p class=\"setting-desc\">Contact an administrator to have goPodder users created for your account.</p>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 150, "<p class=\"setting-desc\">Contact an administrator to have sync logins created for your account.</p>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -1734,7 +1734,7 @@ func UserManagementPage(data UserManagementData) templ.Component {
 					var templ_7745c5c3_Var89 string
 					templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(user.Username)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 588, Col: 26}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 588, Col: 26}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
 					if templ_7745c5c3_Err != nil {
@@ -1747,7 +1747,7 @@ func UserManagementPage(data UserManagementData) templ.Component {
 					var templ_7745c5c3_Var90 string
 					templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(user.Devices))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 589, Col: 37}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 589, Col: 37}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var90))
 					if templ_7745c5c3_Err != nil {
@@ -1760,7 +1760,7 @@ func UserManagementPage(data UserManagementData) templ.Component {
 					var templ_7745c5c3_Var91 string
 					templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(user.Subscriptions))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 590, Col: 43}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 590, Col: 43}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
 					if templ_7745c5c3_Err != nil {
@@ -1773,7 +1773,7 @@ func UserManagementPage(data UserManagementData) templ.Component {
 					var templ_7745c5c3_Var92 string
 					templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(user.LastActivity)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 591, Col: 44}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 591, Col: 44}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
 					if templ_7745c5c3_Err != nil {
@@ -1786,7 +1786,7 @@ func UserManagementPage(data UserManagementData) templ.Component {
 					var templ_7745c5c3_Var93 templ.SafeURL
 					templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/users/" + user.Username))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 594, Col: 59}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 594, Col: 59}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var93))
 					if templ_7745c5c3_Err != nil {
@@ -1804,7 +1804,7 @@ func UserManagementPage(data UserManagementData) templ.Component {
 						var templ_7745c5c3_Var94 templ.SafeURL
 						templ_7745c5c3_Var94, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/opml?user=" + user.Username))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 596, Col: 64}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 596, Col: 64}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var94))
 						if templ_7745c5c3_Err != nil {
@@ -1822,13 +1822,13 @@ func UserManagementPage(data UserManagementData) templ.Component {
 					var templ_7745c5c3_Var95 templ.SafeURL
 					templ_7745c5c3_Var95, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/users/" + user.Username + "/delete"))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 598, Col: 90}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 598, Col: 90}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var95))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 161, "\" style=\"display:inline;\" onsubmit=\"return confirm('Delete this user? This cannot be undone.');\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 161, "\" style=\"display:inline;\" onsubmit=\"return confirm('Delete this sync login? This cannot be undone.');\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -1889,7 +1889,7 @@ func SettingsPage(data SettingsPageData) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 164, "<h1>Settings</h1><p class=\"page-desc\">Configure how goPodder behaves. Changes take effect immediately for all users.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 164, "<h1>Settings</h1><p class=\"page-desc\">Configure how goPodder behaves. Changes take effect immediately for all accounts.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1923,7 +1923,7 @@ func SettingsPage(data SettingsPageData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 169, "> Allow self-registration</label></div><p class=\"setting-desc\">When enabled, a \"Register\" button is shown on the login page. Anyone can create their own account without admin intervention. Self-registered accounts are assigned the \"standard\" role.</p></div><div class=\"section\"><h2>User Management</h2><div class=\"setting-item\"><label for=\"allow-user-creation\"><input type=\"checkbox\" id=\"allow-user-creation\" name=\"allow_user_creation\" value=\"true\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 169, "> Allow self-registration</label></div><p class=\"setting-desc\">When enabled, a \"Register\" button is shown on the login page. Anyone can create their own account without admin intervention. Self-registered accounts are assigned the \"standard\" role.</p></div><div class=\"section\"><h2>Sync Logins</h2><div class=\"setting-item\"><label for=\"allow-user-creation\"><input type=\"checkbox\" id=\"allow-user-creation\" name=\"allow_user_creation\" value=\"true\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1933,20 +1933,20 @@ func SettingsPage(data SettingsPageData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 171, "> Allow users to create goPodder users</label></div><p class=\"setting-desc\">When enabled, standard accounts can create and manage their own goPodder users from the Users tab. When disabled, only admins can create goPodder users for accounts.</p><div class=\"setting-item\"><label for=\"max-users\">Max goPodder users per account</label> <input type=\"number\" id=\"max-users\" name=\"max_users_per_account\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 171, "> Allow accounts to create their own sync logins</label></div><p class=\"setting-desc\">When enabled, standard accounts can create and manage their own sync logins from the Sync Logins tab. When disabled, only admins can create sync logins for accounts.</p><div class=\"setting-item\"><label for=\"max-users\">Max sync logins per account</label> <input type=\"number\" id=\"max-users\" name=\"max_users_per_account\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var98 string
 			templ_7745c5c3_Var98, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprint(data.MaxUsersPerAccount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 657, Col: 113}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 657, Col: 113}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var98)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 172, "\" min=\"0\"></div><p class=\"setting-desc\">Maximum number of goPodder users each account can create. Set to 0 for unlimited.</p><div class=\"setting-item\"><label for=\"allow-sharing\"><input type=\"checkbox\" id=\"allow-sharing\" name=\"allow_sharing\" value=\"true\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 172, "\" min=\"0\"></div><p class=\"setting-desc\">Maximum number of sync logins each account can create. Set to 0 for unlimited.</p><div class=\"setting-item\"><label for=\"allow-sharing\"><input type=\"checkbox\" id=\"allow-sharing\" name=\"allow_sharing\" value=\"true\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1956,7 +1956,7 @@ func SettingsPage(data SettingsPageData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 174, "> Allow subscription sharing</label></div><p class=\"setting-desc\">When enabled, users can generate public links to share their subscriptions as OPML or RSS feeds. When disabled, sharing is not available and existing share links stop working.</p><div class=\"setting-item\"><label for=\"allow-api-keys\"><input type=\"checkbox\" id=\"allow-api-keys\" name=\"allow_api_keys\" value=\"true\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 174, "> Allow subscription sharing</label></div><p class=\"setting-desc\">When enabled, accounts can generate public links to share their subscriptions as OPML or RSS feeds. When disabled, sharing is not available and existing share links stop working.</p><div class=\"setting-item\"><label for=\"allow-api-keys\"><input type=\"checkbox\" id=\"allow-api-keys\" name=\"allow_api_keys\" value=\"true\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1973,7 +1973,7 @@ func SettingsPage(data SettingsPageData) templ.Component {
 			var templ_7745c5c3_Var99 string
 			templ_7745c5c3_Var99, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprint(data.MaxAPIKeys))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 692, Col: 111}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 692, Col: 111}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var99)
 			if templ_7745c5c3_Err != nil {
@@ -1986,20 +1986,20 @@ func SettingsPage(data SettingsPageData) templ.Component {
 			var templ_7745c5c3_Var100 string
 			templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprint(data.MinPasswordLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 700, Col: 114}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 700, Col: 114}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var100)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 178, "\" min=\"0\"></div><p class=\"setting-desc\">Minimum number of characters required for all passwords (accounts and goPodder users). Default is 8. Setting this below 8 weakens security and is not recommended.</p><div class=\"setting-item\"><label for=\"session-max-age\">Session max age (hours)</label> <input type=\"number\" id=\"session-max-age\" name=\"session_max_age_hours\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 178, "\" min=\"0\"></div><p class=\"setting-desc\">Minimum number of characters required for all passwords (accounts and sync logins). Default is 8. Setting this below 8 weakens security and is not recommended.</p><div class=\"setting-item\"><label for=\"session-max-age\">Session max age (hours)</label> <input type=\"number\" id=\"session-max-age\" name=\"session_max_age_hours\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var101 string
 			templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprint(data.SessionMaxAge))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 705, Col: 114}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 705, Col: 114}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var101)
 			if templ_7745c5c3_Err != nil {
@@ -2012,7 +2012,7 @@ func SettingsPage(data SettingsPageData) templ.Component {
 			var templ_7745c5c3_Var102 string
 			templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprint(data.EpisodeRetention))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 713, Col: 120}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 713, Col: 120}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var102)
 			if templ_7745c5c3_Err != nil {
@@ -2025,7 +2025,7 @@ func SettingsPage(data SettingsPageData) templ.Component {
 			var templ_7745c5c3_Var103 string
 			templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprint(data.InactiveAccountDays))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 718, Col: 126}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 718, Col: 126}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var103)
 			if templ_7745c5c3_Err != nil {
@@ -2098,7 +2098,7 @@ func AccountSelfPage(data AccountSelfData) templ.Component {
 				var templ_7745c5c3_Var106 string
 				templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(data.NewKey)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 737, Col: 157}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 737, Col: 157}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
 				if templ_7745c5c3_Err != nil {
@@ -2127,14 +2127,14 @@ func AccountSelfPage(data AccountSelfData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if data.APIKeysAllowed {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 188, "<div class=\"section\"><h2>API Keys</h2><p class=\"setting-desc\">API keys allow programmatic access to manage goPodder users and subscriptions. Authenticate with a Bearer token in the Authorization header.</p><p class=\"setting-desc\"><a href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 188, "<div class=\"section\"><h2>API Keys</h2><p class=\"setting-desc\">API keys allow programmatic access to manage sync logins and subscriptions. Authenticate with a Bearer token in the Authorization header.</p><p class=\"setting-desc\"><a href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var107 templ.SafeURL
 				templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(RepoURL + "/blob/main/APIDOCS.md"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 770, Col: 86}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 770, Col: 86}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var107))
 				if templ_7745c5c3_Err != nil {
@@ -2157,7 +2157,7 @@ func AccountSelfPage(data AccountSelfData) templ.Component {
 						var templ_7745c5c3_Var108 string
 						templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(key.Name)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 784, Col: 23}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 784, Col: 23}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var108))
 						if templ_7745c5c3_Err != nil {
@@ -2170,7 +2170,7 @@ func AccountSelfPage(data AccountSelfData) templ.Component {
 						var templ_7745c5c3_Var109 string
 						templ_7745c5c3_Var109, templ_7745c5c3_Err = templ.JoinStringErrs(key.Prefix)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 785, Col: 38}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 785, Col: 38}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var109))
 						if templ_7745c5c3_Err != nil {
@@ -2183,7 +2183,7 @@ func AccountSelfPage(data AccountSelfData) templ.Component {
 						var templ_7745c5c3_Var110 string
 						templ_7745c5c3_Var110, templ_7745c5c3_Err = templ.JoinStringErrs(key.Role)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 786, Col: 23}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 786, Col: 23}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var110))
 						if templ_7745c5c3_Err != nil {
@@ -2196,7 +2196,7 @@ func AccountSelfPage(data AccountSelfData) templ.Component {
 						var templ_7745c5c3_Var111 string
 						templ_7745c5c3_Var111, templ_7745c5c3_Err = templ.JoinStringErrs(key.CreatedAt)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 787, Col: 42}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 787, Col: 42}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var111))
 						if templ_7745c5c3_Err != nil {
@@ -2209,7 +2209,7 @@ func AccountSelfPage(data AccountSelfData) templ.Component {
 						var templ_7745c5c3_Var112 string
 						templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(key.LastUsed)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 788, Col: 41}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 788, Col: 41}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
 						if templ_7745c5c3_Err != nil {
@@ -2222,7 +2222,7 @@ func AccountSelfPage(data AccountSelfData) templ.Component {
 						var templ_7745c5c3_Var113 templ.SafeURL
 						templ_7745c5c3_Var113, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/account/keys/" + key.ID + "/delete"))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `gopodder/web/pages.templ`, Line: 790, Col: 91}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `pages.templ`, Line: 790, Col: 91}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var113))
 						if templ_7745c5c3_Err != nil {
@@ -2274,7 +2274,7 @@ func AccountSelfPage(data AccountSelfData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 205, " <div class=\"section\"><h2>Delete Account</h2><p class=\"setting-desc\">Permanently delete your account and all associated goPodder users, devices, and subscriptions. This cannot be undone.</p><form method=\"POST\" action=\"/account/delete\" onsubmit=\"return confirm('Are you sure you want to delete your account? All data will be permanently lost.');\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 205, " <div class=\"section\"><h2>Delete Account</h2><p class=\"setting-desc\">Permanently delete your account and all associated sync logins, devices, and subscriptions. This cannot be undone.</p><form method=\"POST\" action=\"/account/delete\" onsubmit=\"return confirm('Are you sure you want to delete your account? All data will be permanently lost.');\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/gopodder/web_handler.go
+++ b/gopodder/web_handler.go
@@ -434,7 +434,7 @@ func (h *WebHandler) handleSelfUserDetail(w http.ResponseWriter, r *http.Request
 		return
 	}
 	acct := webAccountFromContext(r.Context())
-	data := h.buildUserDetailData(r.Context(), r, acct, username, "users", "/users/"+username, "/users", "Back to Users")
+	data := h.buildUserDetailData(r.Context(), r, acct, username, "users", "/users/"+username, "/users", "Back to Sync Logins")
 	data.Flash = r.URL.Query().Get("flash")
 	data.Error = r.URL.Query().Get("error")
 	_ = web.UserDetailPage(data).Render(r.Context(), w)


### PR DESCRIPTION
The UI called the same thing "Users", "goPodder Users" and "goPodder users", and that thing is not a person, its the credential a podcast app syncs with. "Accounts" already meant the actual human login, so "user" pointed at the wrong concept everywhere. This renames the sync credential to "sync login" across nav, headings, empty states, settings, confirm dialogs, README and APIDOCS.

#52 proposed swapping the two terms instead, so "Users" would become the human. I went one-directional on purpose: a swap makes "user" mean the opposite of what it means today, which silently invalidates every existing screenshot, doc and forum answer. This way no term flips. Copy only, so no breaking changes: routes, `/api/v1/*` paths, form field names, activeTab keys, Go types and the DB schema are all untouched. The `/users` URL now differs from its nav label

Closes #52